### PR TITLE
Memory: calculate percentage and available memory on some systems

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -70,8 +70,6 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 		if memStat != nil && hasAvailableMememory {
 			results["available_B"] = int(memStat.Available)
 			results["available_percent"] = floatToIntPercent(float64(results["available_B"].(int)) / float64(memStat.Total))
-		} else {
-			results["available_B"] = nil
 		}
 	}
 

--- a/mem.go
+++ b/mem.go
@@ -19,8 +19,6 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), memGetTimeout)
 	defer cancel()
 
-	memStat, err := mem.VirtualMemoryWithContext(ctx)
-
 	results = map[string]interface{}{
 		"total_B":           nil,
 		"free_B":            nil,
@@ -37,6 +35,7 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 		"available_percent": nil,
 	}
 
+	memStat, err := mem.VirtualMemoryWithContext(ctx)
 	if err != nil {
 		log.Errorf("[MEM] Failed to get virtual memory stat: %s", err.Error())
 		return results, errors.New("MEM: " + err.Error())

--- a/mem.go
+++ b/mem.go
@@ -5,7 +5,6 @@ package cagent
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 	"runtime"
 
@@ -17,8 +16,6 @@ const memGetTimeout = time.Second * 10
 
 func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 	results := MeasurementsMap{}
-
-	var errs []string
 	ctx, cancel := context.WithTimeout(context.Background(), memGetTimeout)
 	defer cancel()
 
@@ -42,40 +39,36 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 
 	if err != nil {
 		log.Errorf("[MEM] Failed to get virtual memory stat: %s", err.Error())
-		errs = append(errs, err.Error())
-	} else {
-		results["total_B"] = memStat.Total
-		results["used_B"] = memStat.Used
-		results["used_percent"] = floatToIntPercent(float64(memStat.Used) / float64(memStat.Total))
-		results["free_B"] = memStat.Free
-		results["free_percent"] = floatToIntPercent(float64(memStat.Free) / float64(memStat.Total))
-		results["shared_B"] = memStat.Shared
-		results["shared_percent"] = floatToIntPercent(float64(memStat.Shared) / float64(memStat.Total))
-		results["cached_B"] = memStat.Cached
-		results["cached_percent"] = floatToIntPercent(float64(memStat.Cached) / float64(memStat.Total))
-		results["shared_percent"] = floatToIntPercent(float64(memStat.Shared) / float64(memStat.Total))
-		results["buff_B"] = memStat.Buffers
-		results["buff_percent"] = floatToIntPercent(float64(memStat.Buffers) / float64(memStat.Total))
-
-		var hasAvailableMemory bool
-		// linux has native MemAvailable metric since 3.14 kernel
-		// others calculated within github.com/shirou/gopsutil
-		switch runtime.GOOS {
-		case "linux", "freebsd", "openbsd", "darwin":
-			hasAvailableMemory = true
-		default:
-			hasAvailableMemory = false
-		}
-
-		if memStat != nil && hasAvailableMemory {
-			results["available_B"] = int(memStat.Available)
-			results["available_percent"] = floatToIntPercent(float64(results["available_B"].(int)) / float64(memStat.Total))
-		}
+		return results, errors.New("MEM: " + err.Error())
 	}
 
-	if len(errs) == 0 {
-		return results, nil
+	results["total_B"] = memStat.Total
+	results["used_B"] = memStat.Used
+	results["used_percent"] = floatToIntPercentRoundUP(float64(memStat.Used) / float64(memStat.Total))
+	results["free_B"] = memStat.Free
+	results["free_percent"] = floatToIntPercentRoundUP(float64(memStat.Free) / float64(memStat.Total))
+	results["shared_B"] = memStat.Shared
+	results["shared_percent"] = floatToIntPercentRoundUP(float64(memStat.Shared) / float64(memStat.Total))
+	results["cached_B"] = memStat.Cached
+	results["cached_percent"] = floatToIntPercentRoundUP(float64(memStat.Cached) / float64(memStat.Total))
+	results["shared_percent"] = floatToIntPercentRoundUP(float64(memStat.Shared) / float64(memStat.Total))
+	results["buff_B"] = memStat.Buffers
+	results["buff_percent"] = floatToIntPercentRoundUP(float64(memStat.Buffers) / float64(memStat.Total))
+
+	var hasAvailableMemory bool
+	// linux has native MemAvailable metric since 3.14 kernel
+	// others calculated within github.com/shirou/gopsutil
+	switch runtime.GOOS {
+	case "linux", "freebsd", "openbsd", "darwin":
+		hasAvailableMemory = true
+	default:
+		hasAvailableMemory = false
 	}
 
-	return results, errors.New("MEM: " + strings.Join(errs, "; "))
+	if memStat != nil && hasAvailableMemory {
+		results["available_B"] = int(memStat.Available)
+		results["available_percent"] = floatToIntPercentRoundUP(float64(results["available_B"].(int)) / float64(memStat.Total))
+	}
+
+	return results, nil
 }

--- a/mem.go
+++ b/mem.go
@@ -57,17 +57,17 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 		results["buff_B"] = memStat.Buffers
 		results["buff_percent"] = floatToIntPercent(float64(memStat.Buffers) / float64(memStat.Total))
 
-		var hasAvailableMememory bool
+		var hasAvailableMemory bool
 		// linux has native MemAvailable metric since 3.14 kernel
 		// others calculated within github.com/shirou/gopsutil
 		switch runtime.GOOS {
 		case "linux", "freebsd", "openbsd", "darwin":
-			hasAvailableMetric = true
+			hasAvailableMemory = true
 		default:
-			hasAvailableMememory = false
+			hasAvailableMemory = false
 		}
 
-		if memStat != nil && hasAvailableMememory {
+		if memStat != nil && hasAvailableMemory {
 			results["available_B"] = int(memStat.Available)
 			results["available_percent"] = floatToIntPercent(float64(results["available_B"].(int)) / float64(memStat.Total))
 		}

--- a/mem_windows.go
+++ b/mem_windows.go
@@ -25,27 +25,43 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 
 	memStat, err := mem.VirtualMemoryWithContext(ctx)
 
-	results["free_B"] = nil
-	results["shared_B"] = nil
-	results["buff_B"] = nil
+	results = map[string]interface{}{
+		"total_B":           nil,
+		"free_B":            nil,
+		"free_percent":      nil,
+		"cached_B":          nil,
+		"cached_percent":    nil,
+		"used_B":            nil,
+		"used_percent":      nil,
+		"available_B":       nil,
+		"available_percent": nil,
+	}
 
 	if err != nil {
 		log.Errorf("[MEM] Failed to get virtual memory stat: %s", err.Error())
 		errs = append(errs, err.Error())
-		results["total_B"] = nil
-		results["used_B"] = nil
-		results["available_B"] = nil
 	} else {
 		results["total_B"] = memStat.Total
-		results["used_B"] = memStat.Used
 		results["available_B"] = memStat.Available
+		results["available_percent"] = floatToIntPercent((float64(memStat.Available)) / float64(memStat.Total))
 	}
 
 	free, err := watcher.Query(`\Memory\Free & Zero Page List Bytes`, "*")
 	if err != nil {
 		log.Errorf("[MEM] Failed to get free memory: %s", err.Error())
 	} else {
-		results["free_B"] = free
+		results["used_B"] = int(memStat.Total) - int(free)
+		results["used_percent"] = floatToIntPercent((float64(memStat.Total) - free) / float64(memStat.Total))
+		results["free_B"] = int(free)
+		results["free_percent"] = floatToIntPercent(free / float64(memStat.Total))
+	}
+
+	cached, err := watcher.Query(`\Memory\Cache Bytes`, "*")
+	if err != nil {
+		log.Errorf("[MEM] Failed to get cached memory: %s", err.Error())
+	} else {
+		results["cached_B"] = int(cached)
+		results["cached_percent"] = floatToIntPercent(float64(cached) / float64(memStat.Total))
 	}
 
 	if len(errs) == 0 {

--- a/types.go
+++ b/types.go
@@ -15,6 +15,6 @@ type Result struct {
 	Message      interface{}     `json:"message"`
 }
 
-func floatToIntPercent(f float64) int{
+func floatToIntPercentRoundUP(f float64) int{
 	return int(f*100+0.5)
 }

--- a/types.go
+++ b/types.go
@@ -14,3 +14,7 @@ type Result struct {
 	Measurements MeasurementsMap `json:"measurements"`
 	Message      interface{}     `json:"message"`
 }
+
+func floatToIntPercent(f float64) int{
+	return int(f*100+0.5)
+}


### PR DESCRIPTION
See DEV-366.
I also improved the `available` memory metric.
- On Linux/Windows it uses the value provided by OS 
- On some OS(OpenBSD, Freebsd, Darwin) it calculated it as `free+cached+buffered` by [gopsutil]( https://github.com/shirou/gopsutil/blob/master/mem)
- Otherwise available metric must be nil