### PR TITLE
Normalise versions with rc suffix

### DIFF
--- a/build-win.bat
+++ b/build-win.bat
@@ -1,5 +1,7 @@
 SET build_dir=C:\Users\hero\cagent_ci\build_msi\%1
 SET cagent_version=%2
+SET cagent_version_normalised=%cagent_version:-rc=.0.%
+IF %cagent_version_normalised% == %cagent_version% SET cagent_version_normalised=%cagent_version_normalised%.1
 SET cert_pass=%3
 
 SET PATH=%PATH%;C:\Program Files (x86)\WiX Toolset v3.11\bin;c:\Program Files (x86)\Windows Kits\10\bin\10.0.17134.0\x86;C:\Program Files\go-msi
@@ -7,11 +9,11 @@ CD %build_dir%
 
 
 COPY dist\cagent_386.exe cagent.exe
-go-msi make --src pkg-scripts\msi-templates --msi dist/cagent_32.msi --version %cagent_version% --arch 386
+go-msi make --src pkg-scripts\msi-templates --msi dist/cagent_32.msi --version %cagent_version_normalised% --arch 386
 DEL cagent.exe
 
 COPY dist\cagent_64.exe cagent.exe
-go-msi make --src pkg-scripts\msi-templates --msi dist/cagent_64.msi --version %cagent_version% --arch amd64
+go-msi make --src pkg-scripts\msi-templates --msi dist/cagent_64.msi --version %cagent_version_normalised% --arch amd64
 DEL cagent.exe
 
 signtool sign /t http://timestamp.digicert.com /f "C:\Users\hero\cagent_ci/build_msi/cloudradar.io.p12" /p %cert_pass% dist/cagent_32.msi


### PR DESCRIPTION
MSI only supports semver (e.g. 1.0.1.2)
In order to provide a clear upgrade flow for MSI, I made some updates to the bat to normalise the version like this:

1.0.2-rc1 -> 1.0.2.0.1
1.0.2-rc2 -> 1.0.2.0.2
1.0.2 -> 1.0.2.1

**Important note: This will provide incorrect version for input version without the patch part, e.g.`1.0`**

This doesn't affects version in the binary itself. Only for the MSI package