### PR TITLE
Set default log level to error

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -26,6 +26,8 @@ var (
 	version string
 )
 
+const defaultLogLevel = "error"
+
 func askForConfirmation(s string) bool {
 	reader := bufio.NewReader(os.Stdin)
 
@@ -62,7 +64,7 @@ func main() {
 	outputFilePtr := flag.String("o", "", "file to write the results")
 
 	cfgPathPtr := flag.String("c", cagent.DefaultCfgPath, "config file path")
-	logLevelPtr := flag.String("v", "", "log level – overrides the level in config file (values \"error\",\"info\",\"debug\")")
+	logLevelPtr := flag.String("v", defaultLogLevel, "log level – overrides the level in config file (values \"error\",\"info\",\"debug\")")
 	systemManager := service.ChosenSystem()
 	daemonizeModePtr := flag.Bool("d", false, "daemonize – run the proccess in background")
 	oneRunOnlyModePtr := flag.Bool("r", false, "one run only – perform checks once and exit. Overwrites output file")
@@ -127,9 +129,13 @@ func main() {
 		log.SetOutput(os.Stderr)
 	}
 
+	// Check loglevel and if needed warn user and set to default
 	if *logLevelPtr == string(cagent.LogLevelError) || *logLevelPtr == string(cagent.LogLevelInfo) || *logLevelPtr == string(cagent.LogLevelDebug) {
 		ca.SetLogLevel(cagent.LogLevel(*logLevelPtr))
+	} else {
+		log.Warnf("LogLevel was set to an invalid value: \"%s\". Set to default: \"%s\"", *logLevelPtr, defaultLogLevel)
 	}
+
 	if ca.HubURL == "" && !*serviceUninstallPtr && *outputFilePtr == "" {
 		if serviceInstallPtr != nil && *serviceInstallPtr || serviceInstallUserPtr != nil && *serviceInstallUserPtr != "" {
 			fmt.Println(" ****** Before start you need to set 'hub_url' config param at ", *cfgPathPtr)

--- a/config.go
+++ b/config.go
@@ -1,18 +1,17 @@
 package cagent
 
 import (
+	"bytes"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
-	"time"
-	"bytes"
-
-	"crypto/x509"
-	"io/ioutil"
-	"net/url"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	log "github.com/sirupsen/logrus"
@@ -52,7 +51,7 @@ type Cagent struct {
 
 	SystemFields []string `toml:"system_fields"`
 
-	WindowsUpdatesWatcherInterval     int     `toml:"windows_updates_watcher_interval"`
+	WindowsUpdatesWatcherInterval int `toml:"windows_updates_watcher_interval"`
 
 	// internal use
 	hubHttpClient *http.Client
@@ -138,7 +137,6 @@ func New() *Cagent {
 		ca.HubPassword = os.Getenv("CAGENT_HUB_PASSWORD")
 	}
 
-	ca.SetLogLevel(LogLevelInfo)
 	return ca
 }
 


### PR DESCRIPTION
Change the default log level `error` and print a warning if the user has set the log level to something we don't expect.