### PR TITLE
Fix regex to properly detect rc versions by tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           shell: /bin/bash
           command: |
-           [[ ${CIRCLE_TAG} =~ (-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$ ]] && github-release edit --user cloudradar-monitoring --repo cagent --tag ${CIRCLE_TAG} -p
+           if [[ ${CIRCLE_TAG} =~ -{1}((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$ ]] ; then github-release edit --user cloudradar-monitoring --repo cagent --tag ${CIRCLE_TAG} -p; fi
       # Create remote build dir
       - run: ssh -i /tmp/id_win_ssh -oStrictHostKeyChecking=no hero@13.80.137.211 mkdir -p /cygdrive/c/Users/hero/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/dist
       # Copy exe files to Windows VM for bundingling and signing


### PR DESCRIPTION
This fixes the detection if a tag is an official release or a rc release