### PR TITLE
set to default log level is the user has provded an invalid value

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -134,6 +134,7 @@ func main() {
 		ca.SetLogLevel(cagent.LogLevel(*logLevelPtr))
 	} else {
 		log.Warnf("LogLevel was set to an invalid value: \"%s\". Set to default: \"%s\"", *logLevelPtr, defaultLogLevel)
+		ca.SetLogLevel(cagent.LogLevel(defaultLogLevel))
 	}
 
 	if ca.HubURL == "" && !*serviceUninstallPtr && *outputFilePtr == "" {


### PR DESCRIPTION
While working on https://github.com/cloudradar-monitoring/cagent/pull/25 I noticed that I actually forgot to set the log level to default when the user provided an invalid value.
Only the warning was printed but that's it.
