### PR TITLE
-t flag to test the HUB connection & creds

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -113,6 +113,8 @@ func main() {
 		err := ca.TestHub()
 		if err != nil {
 			fmt.Printf("Cagent HUB test failed: %s\n", err.Error())
+			os.Exit(1)
+			return
 		}
 
 		fmt.Printf("HUB connection test succeed and credentials are correct!\n")

--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -77,6 +77,7 @@ func main() {
 
 	serviceUninstallPtr := flag.Bool("u", false, fmt.Sprintf("stop and uninstall the system service(%s)", systemManager.String()))
 	printConfigPtr := flag.Bool("p", false, "print the active config")
+	testConfigPtr := flag.Bool("t", false, "test the HUB config")
 	versionPtr := flag.Bool("version", false, "show the cagent version")
 
 	flag.Parse()
@@ -105,6 +106,16 @@ func main() {
 
 	if *printConfigPtr {
 		fmt.Println(ca.DumpConfigToml())
+		return
+	}
+
+	if *testConfigPtr {
+		err := ca.TestHub()
+		if err != nil {
+			fmt.Printf("Cagent HUB test failed: %s\n", err.Error())
+		}
+
+		fmt.Printf("HUB connection test succeed and credentials are correct!\n")
 		return
 	}
 
@@ -141,7 +152,7 @@ func main() {
 		if serviceInstallPtr != nil && *serviceInstallPtr || serviceInstallUserPtr != nil && *serviceInstallUserPtr != "" {
 			fmt.Println(" ****** Before start you need to set 'hub_url' config param at ", *cfgPathPtr)
 		} else {
-			fmt.Println("Missing output file flag(-o) hub_url in config")
+			fmt.Println("Missing output file flag(-o) or hub_url in the config")
 			flag.PrintDefaults()
 			return
 		}

--- a/handler.go
+++ b/handler.go
@@ -52,28 +52,30 @@ func (ca *Cagent) initHubHttpClient() {
 }
 
 func (ca *Cagent) TestHub() error {
+	if ca.HubURL == "" {
+		return fmt.Errorf("please set the hub_url config param")
+	}
+
 	ca.initHubHttpClient()
 	req, err := http.NewRequest("HEAD", ca.HubURL, nil)
-
 	if err != nil {
 		return err
 	}
 
 	req.Header.Add("User-Agent", ca.userAgent())
-
 	if ca.HubUser != "" {
 		req.SetBasicAuth(ca.HubUser, ca.HubPassword)
 	}
 	resp, err := ca.hubHttpClient.Do(req)
 
 	if err != nil {
-		return fmt.Errorf("unable to connect. If you have a proxy or firewall, it may be blocking the connection")
+		return fmt.Errorf("unable to connect. %s. If you have a proxy or firewall, it may be blocking the connection", err.Error())
 	}
 
 	if resp.StatusCode == 401 && ca.HubUser == "" {
-		return fmt.Errorf("unable authorise without credentials. Please specify hub_user & hub_password in the config")
+		return fmt.Errorf("unable to authorise without credentials. Please set hub_user & hub_password in the config")
 	} else if resp.StatusCode == 401 && ca.HubUser != "" {
-		return fmt.Errorf("unable authorise with the provided credentials. Please correct the hub_user & hub_password in the config")
+		return fmt.Errorf("unable to authorise with the provided credentials. Please correct the hub_user & hub_password in the config")
 	} else if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return fmt.Errorf("got bad response status: %d, %s. If you have a proxy or firewall it may be blocking the connection", resp.StatusCode, resp.Status)
 	}

--- a/handler.go
+++ b/handler.go
@@ -66,7 +66,7 @@ func (ca *Cagent) TestHub() error {
 	if ca.HubUser != "" {
 		req.SetBasicAuth(ca.HubUser, ca.HubPassword)
 	}
-	
+
 	resp, err := ca.hubHttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("unable to connect. %s. If you have a proxy or firewall, it may be blocking the connection", err.Error())

--- a/handler.go
+++ b/handler.go
@@ -66,8 +66,8 @@ func (ca *Cagent) TestHub() error {
 	if ca.HubUser != "" {
 		req.SetBasicAuth(ca.HubUser, ca.HubPassword)
 	}
+	
 	resp, err := ca.hubHttpClient.Do(req)
-
 	if err != nil {
 		return fmt.Errorf("unable to connect. %s. If you have a proxy or firewall, it may be blocking the connection", err.Error())
 	}

--- a/pkg-scripts/postinstall.sh
+++ b/pkg-scripts/postinstall.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
 /usr/bin/cagent -s cagent -c /etc/cagent/cagent.conf
+/usr/bin/cagent -t

--- a/pkg-scripts/postinstall.sh
+++ b/pkg-scripts/postinstall.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 /usr/bin/cagent -s cagent -c /etc/cagent/cagent.conf
-/usr/bin/cagent -t
+/usr/bin/cagent -t || true


### PR DESCRIPTION
See DEV-486
We need a way to test the HUB connection & creds.
This will be run as a postscript in pkg installers in order to provide fast feedback for the user. 
It can be useful when a user has firewall blocking outgoing connection or made a typo in the credentials