### PR TITLE
Refactor network.go

### DIFF
--- a/network.go
+++ b/network.go
@@ -113,7 +113,7 @@ func (nw *netWatcher) ExcludedInterfacesByNameMap(allInterfaces []utilnet.Interf
 				nw.constantlyExcludedInterfaceCache[netIf.Name] = false
 				continue
 			}
-			
+
 			excludedInterfaces[netIf.Name] = struct{}{}
 			log.Debugf("[NET] interface excluded: %s", netIf.Name)
 		}
@@ -202,7 +202,7 @@ func (nw *netWatcher) Results() (MeasurementsMap, error) {
 
 	interfaces, err := utilnet.Interfaces()
 	if err != nil {
-		log.Errorf("[NET] Failed to read interfaces: ", err.Error())
+		log.Errorf("[NET] Failed to read interfaces: %s", err.Error())
 		return nil, err
 	}
 

--- a/types.go
+++ b/types.go
@@ -18,3 +18,7 @@ type Result struct {
 func floatToIntPercentRoundUP(f float64) int{
 	return int(f*100+0.5)
 }
+
+func floatToIntRoundUP(f float64) int{
+	return int(f+0.5)
+}


### PR DESCRIPTION
Split big Results() method

gocyclo:
```
12 cagent (*netWatcher).fillCountersMeasurements network.go:136:1
12 cagent (*netWatcher).ExcludedInterfacesByNameMap network.go:88:1
10 cagent IPAddresses network.go:220:1
```