### PR TITLE
refactor handler.go

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -343,12 +343,12 @@ func main() {
 			log.Fatal(err)
 		}
 		return
-	} else {
-		go func() {
-			ca.Run(output, interruptChan)
-			doneChan <- struct{}{}
-		}()
 	}
+
+	go func() {
+		ca.Run(output, interruptChan)
+		doneChan <- struct{}{}
+	}()
 
 	select {
 	case sig := <-sigc:

--- a/config.go
+++ b/config.go
@@ -56,10 +56,10 @@ type Cagent struct {
 	// internal use
 	hubHttpClient *http.Client
 
-	cpuWatcher           *cpuWatcher
-	fsWatcher            *fsWatcher
-	netWatcher           *netWatcher
-	windowsUpdateWatcher *windowsUpdateWatcher
+	cpuWatcher           *CPUWatcher
+	fsWatcher            *FSWatcher
+	netWatcher           *NetWatcher
+	windowsUpdateWatcher *WindowsUpdateWatcher
 
 	rootCAs *x509.CertPool
 	version string

--- a/config.go
+++ b/config.go
@@ -56,8 +56,13 @@ type Cagent struct {
 	// internal use
 	hubHttpClient *http.Client
 
-	rootCAs *x509.CertPool
-	version string
+	cpuWatcher           *cpuWatcher
+	fsWatcher            *fsWatcher
+	netWatcher           *netWatcher
+	windowsUpdateWatcher *windowsUpdateWatcher
+	
+	rootCAs              *x509.CertPool
+	version              string
 }
 
 func New() *Cagent {

--- a/config.go
+++ b/config.go
@@ -60,9 +60,9 @@ type Cagent struct {
 	fsWatcher            *fsWatcher
 	netWatcher           *netWatcher
 	windowsUpdateWatcher *windowsUpdateWatcher
-	
-	rootCAs              *x509.CertPool
-	version              string
+
+	rootCAs *x509.CertPool
+	version string
 }
 
 func New() *Cagent {

--- a/cpu.go
+++ b/cpu.go
@@ -44,7 +44,7 @@ type TimeSeriesAverage struct {
 	_DurationInMinutes []int // do not set directly, use SetDurationsMinutes
 }
 
-type cpuWatcher struct {
+type CPUWatcher struct {
 	LoadAvg1  bool
 	LoadAvg5  bool
 	LoadAvg15 bool
@@ -194,12 +194,12 @@ func (tsa *TimeSeriesAverage) Percentage() (map[int]ValuesMap, error) {
 	return sum, nil
 }
 
-func (ca *Cagent) CPUWatcher() *cpuWatcher {
+func (ca *Cagent) CPUWatcher() *CPUWatcher {
 	if ca.cpuWatcher != nil {
 		return ca.cpuWatcher
 	}
 
-	cw := cpuWatcher{}
+	cw := CPUWatcher{}
 	cw.UtilAvg.mu.Lock()
 
 	if len(ca.CPULoadDataGather) > 0 {
@@ -273,7 +273,7 @@ func (ca *Cagent) CPUWatcher() *cpuWatcher {
 	return ca.cpuWatcher
 }
 
-func (cw *cpuWatcher) Once() error {
+func (cw *CPUWatcher) Once() error {
 
 	cw.UtilAvg.mu.Lock()
 	defer cw.UtilAvg.mu.Unlock()
@@ -360,7 +360,7 @@ func (cw *cpuWatcher) Once() error {
 	return nil
 }
 
-func (cw *cpuWatcher) Run() {
+func (cw *CPUWatcher) Run() {
 	for {
 		start := time.Now()
 		err := cw.Once()
@@ -377,7 +377,7 @@ func (cw *cpuWatcher) Run() {
 	}
 }
 
-func (cw *cpuWatcher) Results() (MeasurementsMap, error) {
+func (cw *CPUWatcher) Results() (MeasurementsMap, error) {
 	var errs []string
 	util, err := cw.UtilAvg.Percentage()
 	if err != nil {

--- a/fs.go
+++ b/fs.go
@@ -14,18 +14,18 @@ import (
 const fsGetUsageTimeout = time.Second * 10
 const fsGetPartitionsTimeout = time.Second * 10
 
-type fsWatcher struct {
+type FSWatcher struct {
 	AllowedTypes      map[string]struct{}
 	ExcludedPathCache map[string]bool
 	cagent            *Cagent
 }
 
-func (ca *Cagent) FSWatcher() *fsWatcher {
+func (ca *Cagent) FSWatcher() *FSWatcher {
 	if ca.fsWatcher != nil {
 		return ca.fsWatcher
 	}
 
-	ca.fsWatcher = &fsWatcher{AllowedTypes: map[string]struct{}{}, ExcludedPathCache: map[string]bool{}, cagent: ca}
+	ca.fsWatcher = &FSWatcher{AllowedTypes: map[string]struct{}{}, ExcludedPathCache: map[string]bool{}, cagent: ca}
 	for _, t := range ca.FSTypeInclude {
 		ca.fsWatcher.AllowedTypes[strings.ToLower(t)] = struct{}{}
 	}
@@ -33,7 +33,7 @@ func (ca *Cagent) FSWatcher() *fsWatcher {
 	return ca.fsWatcher
 }
 
-func (fw *fsWatcher) Results() (MeasurementsMap, error) {
+func (fw *FSWatcher) Results() (MeasurementsMap, error) {
 	results := MeasurementsMap{}
 
 	var errs []string

--- a/fs.go
+++ b/fs.go
@@ -25,7 +25,11 @@ func (ca *Cagent) FSWatcher() *FSWatcher {
 		return ca.fsWatcher
 	}
 
-	ca.fsWatcher = &FSWatcher{AllowedTypes: map[string]struct{}{}, ExcludedPathCache: map[string]bool{}, cagent: ca}
+	ca.fsWatcher = &FSWatcher{
+		AllowedTypes: map[string]struct{}{},
+		ExcludedPathCache: map[string]bool{},
+		cagent: ca,
+	}
 	for _, t := range ca.FSTypeInclude {
 		ca.fsWatcher.AllowedTypes[strings.ToLower(t)] = struct{}{}
 	}

--- a/fs.go
+++ b/fs.go
@@ -26,9 +26,9 @@ func (ca *Cagent) FSWatcher() *FSWatcher {
 	}
 
 	ca.fsWatcher = &FSWatcher{
-		AllowedTypes: map[string]struct{}{},
+		AllowedTypes:      map[string]struct{}{},
 		ExcludedPathCache: map[string]bool{},
-		cagent: ca,
+		cagent:            ca,
 	}
 	for _, t := range ca.FSTypeInclude {
 		ca.fsWatcher.AllowedTypes[strings.ToLower(t)] = struct{}{}

--- a/fs.go
+++ b/fs.go
@@ -21,12 +21,16 @@ type fsWatcher struct {
 }
 
 func (ca *Cagent) FSWatcher() *fsWatcher {
-	fsWatcher := fsWatcher{AllowedTypes: map[string]struct{}{}, ExcludedPathCache: map[string]bool{}, cagent: ca}
-	for _, t := range ca.FSTypeInclude {
-		fsWatcher.AllowedTypes[strings.ToLower(t)] = struct{}{}
+	if ca.fsWatcher != nil {
+		return ca.fsWatcher
 	}
 
-	return &fsWatcher
+	ca.fsWatcher = &fsWatcher{AllowedTypes: map[string]struct{}{}, ExcludedPathCache: map[string]bool{}, cagent: ca}
+	for _, t := range ca.FSTypeInclude {
+		ca.fsWatcher.AllowedTypes[strings.ToLower(t)] = struct{}{}
+	}
+
+	return ca.fsWatcher
 }
 
 func (fw *fsWatcher) Results() (MeasurementsMap, error) {

--- a/handler.go
+++ b/handler.go
@@ -139,6 +139,7 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 		// no need to log because already done inside cpu.Results()
 		errs = append(errs, err.Error())
 	}
+
 	measurements = measurements.AddWithPrefix("cpu.", cpum)
 
 	info, err := ca.HostInfoResults()
@@ -227,11 +228,14 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 }
 
 func (ca *Cagent) ReportMeasurements(measurements MeasurementsMap, outputFile *os.File) error {
-	result := Result{Timestamp: time.Now().Unix(), Measurements: measurements}
+	result := Result{
+		Timestamp: time.Now().Unix(),
+		Measurements: measurements,
+	}
 
 	if outputFile != nil {
 		jsonEncoder := json.NewEncoder(outputFile)
-		err := jsonEncoder.Encode(result)
+		err := jsonEncoder.Encode(&result)
 		if err != nil {
 			return fmt.Errorf("Results json encode error: %s", err.Error())
 		}

--- a/handler.go
+++ b/handler.go
@@ -7,12 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -132,153 +130,137 @@ func (ca *Cagent) PostResultsToHub(result Result) error {
 	return nil
 }
 
-func (ca *Cagent) Run(outputFile *os.File, interrupt chan struct{}, once bool) {
+func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
+	var errs []string
+	var measurements = make(MeasurementsMap)
 
-	var jsonEncoder *json.Encoder
-	if ca.PidFile != "" && !once && runtime.GOOS != "windows" {
-		err := ioutil.WriteFile(ca.PidFile, []byte(strconv.Itoa(os.Getpid())), 0664)
-
-		if err != nil {
-			log.Errorf("Failed to write pid file at: %s", ca.PidFile)
-		}
+	cpum, err := ca.CPUWatcher().Results()
+	if err != nil {
+		// no need to log because already done inside cpu.Results()
+		errs = append(errs, err.Error())
 	}
+	measurements = measurements.AddWithPrefix("cpu.", cpum)
+
+	info, err := ca.HostInfoResults()
+	if err != nil {
+		// no need to log because already done inside HostInfoResults()
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("system.", info)
+
+	ipResults, err := IPAddresses()
+	if err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("system.", ipResults)
+
+	fsResults, err := ca.FSWatcher().Results()
+	if err != nil {
+		// no need to log because already done inside fs.Results()
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("fs.", fsResults)
+
+	netResults, err := ca.NetWatcher().Results()
+	if err != nil {
+		// no need to log because already done inside net.Results()
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("net.", netResults)
+
+	proc, err := ca.ProcessesResult()
+	if err != nil {
+		// no need to log because already done inside ProcessesResult()
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("proc.", proc)
+
+	mem, err := ca.MemResults()
+	if err != nil {
+		// no need to log because already done inside MemResults()
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("mem.", mem)
+
+	swap, err := ca.SwapResults()
+	if err != nil {
+		// no need to log because already done inside MemResults()
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("swap.", swap)
+
+	if runtime.GOOS == "linux" {
+		raid, err := ca.RaidState()
+		if err != nil {
+			// no need to log because already done inside RaidState()
+			errs = append(errs, err.Error())
+		}
+
+		measurements = measurements.AddWithPrefix("raid.", raid)
+	}
+
+	if runtime.GOOS == "windows" {
+		wu, err := ca.WindowsUpdatesWatcher().WindowsUpdates()
+		if err != nil {
+			// no need to log because already done inside MemResults()
+			errs = append(errs, err.Error())
+		}
+
+		measurements = measurements.AddWithPrefix("windows_update.", wu)
+	}
+
+	if len(errs) == 0 {
+		measurements["cagent.success"] = 1
+		return measurements, nil
+	}
+
+	measurements["cagent.success"] = 0
+
+	return measurements, errors.New(strings.Join(errs, "; "))
+}
+
+func (ca *Cagent) ReportMeasurements(measurements MeasurementsMap, outputFile *os.File) error {
+	result := Result{Timestamp: time.Now().Unix(), Measurements: measurements}
 
 	if outputFile != nil {
-		jsonEncoder = json.NewEncoder(outputFile)
-	}
-
-	var cpu *CPUWatcher
-
-	if len(ca.CPUUtilTypes) > 0 && len(ca.CPUUtilDataGather) > 0 || len(ca.CPULoadDataGather) > 0 {
-		// optimization to prevent CPU watcher to run in case CPU util metrics not are not needed
-		cpu = ca.CPUWatcher()
-		err := cpu.Once()
+		jsonEncoder := json.NewEncoder(outputFile)
+		err := jsonEncoder.Encode(result)
 		if err != nil {
-			log.Error("[CPU] Failed to read utilisation metrics: " + err.Error())
-		}
-		if !once {
-			go cpu.Run()
+			return fmt.Errorf("Results json encode error: %s", err.Error())
 		}
 	}
 
-	fs := ca.FSWatcher()
-	net := ca.NetWatcher()
-	wuw := ca.WindowsUpdatesWatcher()
+	err := ca.PostResultsToHub(result)
+	if err != nil {
+		return fmt.Errorf("POST to hub error: %s", err.Error())
+	}
 
+	return nil
+}
+
+func (ca *Cagent) RunOnce(outputFile *os.File) error {
+	measurements, err := ca.GetAllMeasurements()
+	if err != nil {
+		// don't need to log or return it here – just add the message to report
+		// it is already logged (down into the GetAllMeasurements)
+		measurements["message"] = err.Error()
+	}
+
+	return ca.ReportMeasurements(measurements, outputFile)
+}
+
+func (ca *Cagent) Run(outputFile *os.File, interrupt chan struct{}) {
 	for {
-		results := Result{Timestamp: time.Now().Unix(), Measurements: make(MeasurementsMap)}
-		errs := []string{}
-
-		if cpu != nil {
-			cpum, err := cpu.Results()
-
-			log.Debugf("[CPU] got %d metrics", len(cpum))
-
-			if err != nil {
-				// no need to log because already done inside cpu.Results()
-				errs = append(errs, err.Error())
-			}
-
-			results.Measurements = results.Measurements.AddWithPrefix("cpu.", cpum)
-		}
-
-		info, err := ca.HostInfoResults()
+		err := ca.RunOnce(outputFile)
 		if err != nil {
-			// no need to log because already done inside HostInfoResults()
-			errs = append(errs, err.Error())
-		}
-
-		results.Measurements = results.Measurements.AddWithPrefix("system.", info)
-
-		ipResults, err := IPAddresses()
-		if err != nil {
-			errs = append(errs, err.Error())
-		}
-
-		results.Measurements = results.Measurements.AddWithPrefix("system.", ipResults)
-
-		fsResults, err := fs.Results()
-		if err != nil {
-			// no need to log because already done inside fs.Results()
-			errs = append(errs, err.Error())
-		}
-
-		results.Measurements = results.Measurements.AddWithPrefix("fs.", fsResults)
-
-		netResults, err := net.Results()
-		if err != nil {
-			// no need to log because already done inside net.Results()
-			errs = append(errs, err.Error())
-		}
-
-		results.Measurements = results.Measurements.AddWithPrefix("net.", netResults)
-
-		proc, err := ca.ProcessesResult()
-		if err != nil {
-			// no need to log because already done inside ProcessesResult()
-			errs = append(errs, err.Error())
-		}
-
-		results.Measurements = results.Measurements.AddWithPrefix("proc.", proc)
-
-		mem, err := ca.MemResults()
-		if err != nil {
-			// no need to log because already done inside MemResults()
-			errs = append(errs, err.Error())
-		}
-
-		results.Measurements = results.Measurements.AddWithPrefix("mem.", mem)
-
-		swap, err := ca.SwapResults()
-		if err != nil {
-			// no need to log because already done inside MemResults()
-			errs = append(errs, err.Error())
-		}
-
-		results.Measurements = results.Measurements.AddWithPrefix("swap.", swap)
-
-		if runtime.GOOS == "linux" {
-			raid, err := ca.RaidState()
-			if err != nil {
-				// no need to log because already done inside RaidState()
-				errs = append(errs, err.Error())
-			}
-
-			results.Measurements = results.Measurements.AddWithPrefix("raid.", raid)
-		}
-
-		if runtime.GOOS == "windows" {
-			wu, err := wuw.WindowsUpdates()
-
-			results.Measurements = results.Measurements.AddWithPrefix("windows_update.", wu)
-
-			if err != nil {
-				// no need to log because already done inside MemResults()
-				errs = append(errs, err.Error())
-			}
-		}
-
-		if len(errs) == 0 {
-			results.Measurements["cagent.success"] = 1
-		} else {
-			results.Message = strings.Join(errs, "; ")
-			results.Measurements["cagent.success"] = 0
-		}
-
-		if outputFile != nil {
-			err = jsonEncoder.Encode(results)
-			if err != nil {
-				log.Errorf("Results json encode error: %s", err.Error())
-			}
-		} else {
-			err = ca.PostResultsToHub(results)
-			if err != nil {
-				log.Errorf("POST to hub error: %s", err.Error())
-			}
-		}
-
-		if once {
-			break
+			log.Error(err)
 		}
 
 		select {

--- a/handler.go
+++ b/handler.go
@@ -229,7 +229,7 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 
 func (ca *Cagent) ReportMeasurements(measurements MeasurementsMap, outputFile *os.File) error {
 	result := Result{
-		Timestamp: time.Now().Unix(),
+		Timestamp:    time.Now().Unix(),
 		Measurements: measurements,
 	}
 

--- a/network.go
+++ b/network.go
@@ -14,7 +14,7 @@ import (
 
 const netGetCountersTimeout = time.Second * 10
 
-type netWatcher struct {
+type NetWatcher struct {
 	cagent           *Cagent
 	lastIOCounters   []utilnet.IOCountersStat
 	lastIOCountersAt *time.Time
@@ -23,12 +23,12 @@ type netWatcher struct {
 	constantlyExcludedInterfaceCache map[string]bool
 }
 
-func (ca *Cagent) NetWatcher() *netWatcher {
+func (ca *Cagent) NetWatcher() *NetWatcher {
 	if ca.netWatcher != nil {
 		return ca.netWatcher
 	}
 
-	ca.netWatcher = &netWatcher{
+	ca.netWatcher = &NetWatcher{
 		cagent:                           ca,
 		constantlyExcludedInterfaceCache: map[string]bool{},
 	}
@@ -37,7 +37,7 @@ func (ca *Cagent) NetWatcher() *netWatcher {
 
 // InterfaceExcludeRegexCompiled compiles and cache all the interfaces-filtering regexp's user has specified in the config
 // So we don't need to compile them on each iteration of measurements
-func (nw *netWatcher) InterfaceExcludeRegexCompiled() []*regexp.Regexp {
+func (nw *NetWatcher) InterfaceExcludeRegexCompiled() []*regexp.Regexp {
 	if len(nw.netInterfaceExcludeRegexCompiled) > 0 {
 		return nw.netInterfaceExcludeRegexCompiled
 	}
@@ -77,7 +77,7 @@ func isInterfaceDown(netIf *utilnet.InterfaceStat) bool {
 	return true
 }
 
-func (nw *netWatcher) isInterfaceExcludedByName(netIf *utilnet.InterfaceStat) bool {
+func (nw *NetWatcher) isInterfaceExcludedByName(netIf *utilnet.InterfaceStat) bool {
 	for _, excludedIf := range nw.cagent.NetInterfaceExclude {
 		if strings.EqualFold(netIf.Name, excludedIf) {
 			return true
@@ -86,7 +86,7 @@ func (nw *netWatcher) isInterfaceExcludedByName(netIf *utilnet.InterfaceStat) bo
 	return false
 }
 
-func (nw *netWatcher) isInterfaceExcludedByRegexp(netIf *utilnet.InterfaceStat) bool {
+func (nw *NetWatcher) isInterfaceExcludedByRegexp(netIf *utilnet.InterfaceStat) bool {
 	for _, re := range nw.InterfaceExcludeRegexCompiled() {
 		if re.MatchString(netIf.Name) {
 			return true
@@ -95,7 +95,7 @@ func (nw *netWatcher) isInterfaceExcludedByRegexp(netIf *utilnet.InterfaceStat) 
 	return false
 }
 
-func (nw *netWatcher) ExcludedInterfacesByName(allInterfaces []utilnet.InterfaceStat) map[string]struct{} {
+func (nw *NetWatcher) ExcludedInterfacesByName(allInterfaces []utilnet.InterfaceStat) map[string]struct{} {
 	excludedInterfaces := map[string]struct{}{}
 
 	for _, netIf := range allInterfaces {
@@ -133,7 +133,7 @@ func (nw *netWatcher) ExcludedInterfacesByName(allInterfaces []utilnet.Interface
 
 // fillEmptyMeasurements used to fill measurements with nil's for all non-excluded interfaces
 // It is called in case measurements are not yet ready or some error happens while retrieving counters
-func (nw *netWatcher) fillEmptyMeasurements(results MeasurementsMap, interfaces []utilnet.InterfaceStat, excludedInterfacesByName map[string]struct{}) {
+func (nw *NetWatcher) fillEmptyMeasurements(results MeasurementsMap, interfaces []utilnet.InterfaceStat, excludedInterfacesByName map[string]struct{}) {
 	for _, netIf := range interfaces {
 		if _, isExcluded := excludedInterfacesByName[netIf.Name]; isExcluded {
 			continue
@@ -146,7 +146,7 @@ func (nw *netWatcher) fillEmptyMeasurements(results MeasurementsMap, interfaces 
 }
 
 // fillCountersMeasurements used to fill measurements with nil's for all non-excluded interfaces
-func (nw *netWatcher) fillCountersMeasurements(results MeasurementsMap, interfaces []utilnet.InterfaceStat, excludedInterfacesByName map[string]struct{}) error {
+func (nw *NetWatcher) fillCountersMeasurements(results MeasurementsMap, interfaces []utilnet.InterfaceStat, excludedInterfacesByName map[string]struct{}) error {
 	ctx, _ := context.WithTimeout(context.Background(), netGetCountersTimeout)
 	counters, err := utilnet.IOCountersWithContext(ctx, true)
 	if err != nil {
@@ -210,7 +210,7 @@ func (nw *netWatcher) fillCountersMeasurements(results MeasurementsMap, interfac
 	return nil
 }
 
-func (nw *netWatcher) Results() (MeasurementsMap, error) {
+func (nw *NetWatcher) Results() (MeasurementsMap, error) {
 	results := MeasurementsMap{}
 
 	interfaces, err := utilnet.Interfaces()

--- a/network.go
+++ b/network.go
@@ -24,7 +24,12 @@ type netWatcher struct {
 }
 
 func (ca *Cagent) NetWatcher() *netWatcher {
-	return &netWatcher{cagent: ca, constantlyExcludedInterfaceCache: map[string]bool{}}
+	if ca.netWatcher != nil {
+		return ca.netWatcher
+	}
+
+	ca.netWatcher = &netWatcher{cagent: ca, constantlyExcludedInterfaceCache: map[string]bool{}}
+	return ca.netWatcher
 }
 
 // InterfaceExcludeRegexCompiled compiles and cache all the interfaces-filtering regexp's user has specified in the config

--- a/network.go
+++ b/network.go
@@ -29,7 +29,7 @@ func (ca *Cagent) NetWatcher() *netWatcher {
 	}
 
 	ca.netWatcher = &netWatcher{
-		cagent: ca,
+		cagent:                           ca,
 		constantlyExcludedInterfaceCache: map[string]bool{},
 	}
 	return ca.netWatcher

--- a/network.go
+++ b/network.go
@@ -28,7 +28,10 @@ func (ca *Cagent) NetWatcher() *netWatcher {
 		return ca.netWatcher
 	}
 
-	ca.netWatcher = &netWatcher{cagent: ca, constantlyExcludedInterfaceCache: map[string]bool{}}
+	ca.netWatcher = &netWatcher{
+		cagent: ca,
+		constantlyExcludedInterfaceCache: map[string]bool{},
+	}
 	return ca.netWatcher
 }
 

--- a/windows.go
+++ b/windows.go
@@ -21,7 +21,7 @@ const (
 	WUStatusAborted
 )
 
-type windowsUpdateWatcher struct {
+type WindowsUpdateWatcher struct {
 	LastFetchedAt time.Time
 	Available     int
 	Pending       int
@@ -137,12 +137,12 @@ func windowsUpdates() (available int, pending int, err error) {
 	return
 }
 
-func (ca *Cagent) WindowsUpdatesWatcher() *windowsUpdateWatcher {
+func (ca *Cagent) WindowsUpdatesWatcher() *WindowsUpdateWatcher {
 	if ca.windowsUpdateWatcher != nil {
 		return ca.windowsUpdateWatcher
 	}
 
-	ca.windowsUpdateWatcher = &windowsUpdateWatcher{ca: ca}
+	ca.windowsUpdateWatcher = &WindowsUpdateWatcher{ca: ca}
 
 	go func() {
 		for {
@@ -159,7 +159,7 @@ func (ca *Cagent) WindowsUpdatesWatcher() *windowsUpdateWatcher {
 	return ca.windowsUpdateWatcher
 }
 
-func (wuw *windowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
+func (wuw *WindowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
 	results := MeasurementsMap{}
 	if wuw.LastFetchedAt.IsZero() {
 		results["updates_available"] = nil

--- a/windows.go
+++ b/windows.go
@@ -21,7 +21,7 @@ const (
 	WUStatusAborted
 )
 
-type WindowsUpdateWatcher struct {
+type windowsUpdateWatcher struct {
 	LastFetchedAt time.Time
 	Available     int
 	Pending       int
@@ -137,25 +137,29 @@ func windowsUpdates() (available int, pending int, err error) {
 	return
 }
 
-func (ca *Cagent) WindowsUpdatesWatcher() *WindowsUpdateWatcher {
-	wuw := &WindowsUpdateWatcher{ca: ca}
+func (ca *Cagent) WindowsUpdatesWatcher() *windowsUpdateWatcher {
+	if ca.windowsUpdateWatcher != nil {
+		return ca.windowsUpdateWatcher
+	}
+
+	ca.windowsUpdateWatcher = &windowsUpdateWatcher{ca: ca}
 
 	go func() {
 		for {
 			available, pending, err := windowsUpdates()
-			wuw.LastFetchedAt = time.Now()
-			wuw.Err = err
-			wuw.Available = available
-			wuw.Pending = pending
+			ca.windowsUpdateWatcher.LastFetchedAt = time.Now()
+			ca.windowsUpdateWatcher.Err = err
+			ca.windowsUpdateWatcher.Available = available
+			ca.windowsUpdateWatcher.Pending = pending
 
 			time.Sleep(time.Second * time.Duration(ca.WindowsUpdatesWatcherInterval))
 		}
 	}()
 
-	return wuw
+	return ca.windowsUpdateWatcher
 }
 
-func (wuw *WindowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
+func (wuw *windowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
 	results := MeasurementsMap{}
 	if wuw.LastFetchedAt.IsZero() {
 		results["updates_available"] = nil

--- a/windows_fallback.go
+++ b/windows_fallback.go
@@ -2,12 +2,12 @@
 
 package cagent
 
-type windowsUpdateWatcher struct{}
+type WindowsUpdateWatcher struct{}
 
-func (ca *Cagent) WindowsUpdatesWatcher() *windowsUpdateWatcher {
-	return &windowsUpdateWatcher{}
+func (ca *Cagent) WindowsUpdatesWatcher() *WindowsUpdateWatcher {
+	return &WindowsUpdateWatcher{}
 }
 
-func (ca *windowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
+func (ca *WindowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
 	return MeasurementsMap{}, nil
 }

--- a/windows_fallback.go
+++ b/windows_fallback.go
@@ -2,12 +2,12 @@
 
 package cagent
 
-type EmptyWindowsUpdateWatcher struct{}
+type windowsUpdateWatcher struct{}
 
-func (ca *Cagent) WindowsUpdatesWatcher() EmptyWindowsUpdateWatcher {
-	return EmptyWindowsUpdateWatcher{}
+func (ca *Cagent) WindowsUpdatesWatcher() *windowsUpdateWatcher {
+	return &windowsUpdateWatcher{}
 }
 
-func (ca *EmptyWindowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
+func (ca *windowsUpdateWatcher) WindowsUpdates() (MeasurementsMap, error) {
 	return MeasurementsMap{}, nil
 }


### PR DESCRIPTION
- Split Run() method into (Run, RunOnce, GetAllMeasurements, ReportMeasurements)
- Move watchers into the Cagent struct

gocyclo before:
```
32 cagent (*Cagent).Run handler.go:135:1
11 cagent (*Cagent).TestHub handler.go:54:1
8 cagent (*Cagent).PostResultsToHub handler.go:86:1
7 cagent (*Cagent).initHubHttpClient handler.go:22:1
```
after: 
```
14 cagent (*Cagent).GetAllMeasurements handler.go:133:1
11 cagent (*Cagent).TestHub handler.go:52:1
8 cagent (*Cagent).PostResultsToHub handler.go:84:1
7 cagent (*Cagent).initHubHttpClient handler.go:20:1
5 cagent (*Cagent).Run handler.go:259:1
```

Todo: 
- Move different watchers into /pkg/monitoring
- Create an interface(New, Results)
- Make the code less repetitive (init watcher, get measurements, fill results map with a prefix)

But I think it is a good idea to merge this PR first