### PR TITLE
fix file output mode

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -121,6 +121,9 @@ func main() {
 	handleFlagDaemonizeMode(*daemonizeModePtr)
 
 	output := handleFlagOutput(*outputFilePtr, *oneRunOnlyModePtr)
+	if output != nil {
+		defer output.Close()
+	}
 
 	handleFlagOneRunOnlyMode(ca, *oneRunOnlyModePtr, output)
 
@@ -211,7 +214,6 @@ func handleFlagOutput(outputFile string, oneRunOnlyMode bool) *os.File {
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to open the output file: '%s'", outputFile)
 	}
-	defer output.Close()
 
 	return output
 }

--- a/handler.go
+++ b/handler.go
@@ -239,6 +239,8 @@ func (ca *Cagent) ReportMeasurements(measurements MeasurementsMap, outputFile *o
 		if err != nil {
 			return fmt.Errorf("Results json encode error: %s", err.Error())
 		}
+
+		return nil
 	}
 
 	err := ca.PostResultsToHub(result)


### PR DESCRIPTION
after refactoring, file output mode was partly broken
- in run-once mode file was closed before output
- results was still pushed to the HUB even file output mode is active