### PR TITLE
doc: mention plesk depends on cagent config path

### DIFF
--- a/pkg-scripts/postinstall.sh
+++ b/pkg-scripts/postinstall.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
+
+# WARN: path to config is referenced by plesk extension
+#       when enabling/disabling plugin thus plesk extension
+#       has to be updated prior to cagent
 /usr/bin/cagent -s cagent -c /etc/cagent/cagent.conf
 /usr/bin/cagent -t || true


### PR DESCRIPTION
Plesk extension management (enable|disable) relies on default config path
Warn plesk must be update prior to do it in the cagent