### PR TITLE
fix: do not fail if dmidecode is not present

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -147,6 +147,7 @@ func (ca *Cagent) PostResultsToHub(result Result) error {
 
 func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 	var errs []string
+
 	var measurements = make(MeasurementsMap)
 
 	cpum, err := ca.CPUWatcher().Results()
@@ -221,9 +222,9 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 	})
 
 	ca.hwInventory.Do(func() {
-		if hwInfo, err := hwinfo.Inventory(); err != nil {
+		if hwInfo, err := hwinfo.Inventory(); err != nil && err != hwinfo.ErrNotPresent {
 			errs = append(errs, err.Error())
-		} else {
+		} else if err == nil {
 			measurements = measurements.AddInnerWithPrefix("hw.inventory", hwInfo)
 		}
 	})
@@ -266,6 +267,7 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 
 	if len(errs) == 0 {
 		measurements["cagent.success"] = 1
+
 		return measurements, nil
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -147,7 +147,6 @@ func (ca *Cagent) PostResultsToHub(result Result) error {
 
 func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 	var errs []string
-
 	var measurements = make(MeasurementsMap)
 
 	cpum, err := ca.CPUWatcher().Results()

--- a/pkg/hwinfo/hwinfo.go
+++ b/pkg/hwinfo/hwinfo.go
@@ -1,5 +1,11 @@
 package hwinfo
 
+import (
+	"errors"
+)
+
+var ErrNotPresent = errors.New("hwinfo: not present")
+
 func Inventory() (map[string]interface{}, error) {
 	hw, err := fetchInventory()
 	if err != nil {

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -11,7 +11,20 @@ import (
 	"github.com/cloudradar-monitoring/dmidecode"
 )
 
+func isCommandAvailable(name string) bool {
+	cmd := exec.Command("/bin/sh", "-c", "command -v "+name)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
+}
+
 func fetchInventory() (map[string]interface{}, error) {
+	// check dmidecode is present in the system
+	if !isCommandAvailable("dmidecode") {
+		return nil, ErrNotPresent
+	}
+
 	// expecting /etc/sudoers.d/cagent-dmidecode is present
 	cmd := exec.Command("/bin/sh", "-c", "sudo dmidecode")
 


### PR DESCRIPTION
Report `cagent.success: 1` if `dmidecode` tool is not present if the system