### PR TITLE
remove service install hub_url fatal error

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -305,11 +305,6 @@ func handleFlagServiceInstall(ca *cagent.Cagent, systemManager service.System, s
 		os.Exit(1)
 	}
 
-	if ca.Config.HubURL == "" {
-		fmt.Printf("To install the service you first need to set 'hub_url' config param")
-		os.Exit(1)
-	}
-
 	if runtime.GOOS != "windows" {
 		userName := *serviceInstallUserPtr
 		u, err := user.Lookup(userName)
@@ -372,20 +367,16 @@ func handleFlagServiceInstall(ca *cagent.Cagent, systemManager service.System, s
 		fmt.Println(err.Error())
 	}
 
-	switch systemManager.String() {
-	case "unix-systemv":
-		fmt.Printf("Run this command to stop it:\nsudo service %s stop\n\n", svcConfig.Name)
-	case "linux-upstart":
-		fmt.Printf("Run this command to stop it:\nsudo initctl stop %s\n\n", svcConfig.Name)
-	case "linux-systemd":
-		fmt.Printf("Run this command to stop it:\nsudo systemctl stop %s.service\n\n", svcConfig.Name)
-	case "darwin-launchd":
-		fmt.Printf("Run this command to stop it:\nsudo launchctl unload %s\n\n", svcConfig.Name)
-	case "windows-service":
-		fmt.Printf("Use the Windows Service Manager to stop it\n\n")
+	fmt.Printf("Log file located at: %s\n", ca.Config.LogFile)
+	fmt.Printf("Config file located at: %s\n", cfgPath)
+
+	if ca.Config.HubURL == "" {
+		fmt.Printf(`*** Attention: 'hub_url' config param is empty.\n
+*** You need to put the right credentials from your Cloudradar account into the config and then restart the service\n\n`)
 	}
 
-	fmt.Printf("Log file located at: %s\n", cfgPath)
+	fmt.Printf("Run this command to restart the service: %s\n\n", getSystemMangerCommand(systemManager.String(), svcConfig.Name, "restart"))
+
 	os.Exit(0)
 }
 
@@ -533,4 +524,29 @@ func setDefaultLogFormatter() {
 	}
 
 	log.SetFormatter(&tfmt)
+}
+
+func getSystemMangerCommand(manager string, service string, command string) string {
+	switch manager {
+	case "unix-systemv":
+		return "sudo service " + service + " " + command
+	case "linux-upstart":
+		return "sudo initctl " + command + " " + service
+	case "linux-systemd":
+		return "sudo systemctl " + command + " " + service + ".service"
+	case "darwin-launchd":
+		switch command {
+		case "stop":
+			command = "unload"
+		case "start":
+			command = "load"
+		case "restart":
+			return "sudo launchctl unload " + service + " && sudo launchctl load " + service
+		}
+		return "sudo launchctl " + command + " " + service
+	case "windows-service":
+		return "sc " + command + " " + service
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
- do not exit if hub_url is not set. Instead, show the steps to fix this
- fix log path(was config path instead)

This allows `dpkg -i` to install cagent service without credentials and put them later