### PR TITLE
Disable docker on windows

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -257,7 +257,7 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 	measurements = measurements.AddWithPrefix("services.", servicesList)
 
 	containersList, err := docker.ListContainers()
-	if err != nil {
+	if err != nil && err != docker.ErrorNotImplementedForOS {
 		// no need to log because already done inside ListContainers()
 		errs = append(errs, err.Error())
 	}

--- a/pkg/monitoring/docker/docker.go
+++ b/pkg/monitoring/docker/docker.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package docker
 
 import (

--- a/pkg/monitoring/docker/docker_common.go
+++ b/pkg/monitoring/docker/docker_common.go
@@ -1,0 +1,8 @@
+package docker
+
+import (
+	"errors"
+	"runtime"
+)
+
+var ErrorNotImplementedForOS = errors.New("Docker support not implemented for " + runtime.GOOS)

--- a/pkg/monitoring/docker/docker_windows.go
+++ b/pkg/monitoring/docker/docker_windows.go
@@ -7,5 +7,5 @@ func ListContainers() (map[string]interface{}, error) {
 }
 
 func ContainerNameByID(_ string) (string, error) {
-	return "", nil
+	return "", ErrorNotImplementedForOS
 }

--- a/pkg/monitoring/docker/docker_windows.go
+++ b/pkg/monitoring/docker/docker_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package docker
+
+func ListContainers() (map[string]interface{}, error) {
+	return nil, ErrorNotImplementedForOS
+}
+
+func ContainerNameByID(_ string) (string, error) {
+	return "", nil
+}

--- a/processes_notwindows.go
+++ b/processes_notwindows.go
@@ -121,7 +121,7 @@ func processesFromProc() ([]ProcStat, error) {
 			if len(reParts) > 0 {
 				containerID := reParts[1]
 				containerName, err := docker.ContainerNameByID(containerID)
-				if err != nil {
+				if err != nil && err != docker.ErrorNotImplementedForOS {
 					log.Errorf("[PROC] failed to read docker container name by id(%s): %s", containerID, err.Error())
 				} else {
 					stat.Container = containerName


### PR DESCRIPTION
- Currently, it tries to connect to the Unix socket on windows, producing errors
- It is still possible to use it on windows via a named pipe, but @thorstenkramm said that we should disable docker on Windows as this is is a pretty rare case.
- As advantage, this saves some binary size on Windows :)