### PR TITLE
Improve services list

### DIFF
--- a/config.go
+++ b/config.go
@@ -67,6 +67,8 @@ type Config struct {
 	VirtualMachinesStat []string `toml:"virtual_machines_stat" comment:"default ['hyper-v'], available options 'hyper-v'"`
 
 	HardwareInventory bool `toml:"hardware_inventory" comment:"default true"`
+
+	DiscoverAutostartingServicesOnly bool `toml:"discover_autostarting_services_only" comment:"default true"`
 }
 
 func init() {
@@ -92,20 +94,21 @@ func init() {
 
 func NewConfig() *Config {
 	cfg := &Config{
-		LogFile:                         defaultLogPath,
-		Interval:                        90,
-		CPULoadDataGather:               []string{"avg1"},
-		CPUUtilTypes:                    []string{"user", "system", "idle", "iowait"},
-		CPUUtilDataGather:               []string{"avg1"},
-		FSTypeInclude:                   []string{"ext3", "ext4", "xfs", "jfs", "ntfs", "btrfs", "hfs", "apfs", "fat32"},
-		FSMetrics:                       []string{"free_B", "free_percent", "total_B"},
-		NetMetrics:                      []string{"in_B_per_s", "out_B_per_s"},
-		NetInterfaceExcludeDisconnected: true,
-		NetInterfaceExclude:             []string{},
-		NetInterfaceExcludeRegex:        []string{},
-		NetInterfaceExcludeLoopback:     true,
-		SystemFields:                    []string{"uname", "os_kernel", "os_family", "os_arch", "cpu_model", "fqdn", "memory_total_B"},
-		HardwareInventory:               true,
+		LogFile:                          defaultLogPath,
+		Interval:                         90,
+		CPULoadDataGather:                []string{"avg1"},
+		CPUUtilTypes:                     []string{"user", "system", "idle", "iowait"},
+		CPUUtilDataGather:                []string{"avg1"},
+		FSTypeInclude:                    []string{"ext3", "ext4", "xfs", "jfs", "ntfs", "btrfs", "hfs", "apfs", "fat32"},
+		FSMetrics:                        []string{"free_B", "free_percent", "total_B"},
+		NetMetrics:                       []string{"in_B_per_s", "out_B_per_s"},
+		NetInterfaceExcludeDisconnected:  true,
+		NetInterfaceExclude:              []string{},
+		NetInterfaceExcludeRegex:         []string{},
+		NetInterfaceExcludeLoopback:      true,
+		SystemFields:                     []string{"uname", "os_kernel", "os_family", "os_arch", "cpu_model", "fqdn", "memory_total_B"},
+		HardwareInventory:                true,
+		DiscoverAutostartingServicesOnly: true,
 	}
 
 	if runtime.GOOS == "windows" {

--- a/example.config.toml
+++ b/example.config.toml
@@ -37,3 +37,6 @@ system_fields = ['uname','os_kernel','os_family','os_arch','cpu_model','fqdn','m
 
 # Windows
 windows_updates_watcher_interval = 3600 # default 3600
+
+hardware_inventory = true
+discover_autostarting_services_only = true

--- a/handler.go
+++ b/handler.go
@@ -248,7 +248,7 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 		measurements = measurements.AddWithPrefix("windows_update.", wu)
 	}
 
-	servicesList, err := services.ListServices()
+	servicesList, err := services.ListServices(ca.Config.DiscoverAutostartingServicesOnly)
 	if err != nil && err != services.ErrorNotImplementedForOS {
 		// no need to log because already done inside ListServices()
 		errs = append(errs, err.Error())

--- a/pkg/monitoring/services/services.go
+++ b/pkg/monitoring/services/services.go
@@ -23,20 +23,92 @@ var ErrorNotImplementedForOS = errors.New("Services list not implemented for " +
 // SystemdService contains the service's data parsed from systemctl
 type SystemdService struct {
 	UnitFile    string
+	UnitState   string
 	LoadState   string
 	ActiveState string
-	SubState    string
+	State       string
 	Description string
 }
 
 // SysVService contains the service's data parsed from service(Sysvinit) or initctl(Upstart)
 type SysVService struct {
 	UnitFile string
-	Status   string
+	State    string
+}
+
+// systemdUnitFilesState provides the map of unit files states
+func systemdUnitFilesState() (map[string]string, error) {
+	cmd := exec.Command("systemctl",
+		"--type=service", // show only services(ignore .mount, .target, .path, .socket etc.)
+		"--all",          // show loaded but inactive services too
+		"--no-pager",     // disable results pagination
+		"--plain",        // disable colors and status bullet
+		"list-unit-files")
+	setPathEnvVar(cmd)
+
+	var outb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &outb
+	err := cmd.Run()
+	if err != nil {
+		errOutput, _ := ioutil.ReadAll(&outb)
+		return nil, fmt.Errorf("Systemctl list-unit-files: %s, %s", err.Error(), string(errOutput))
+	}
+
+	var servicesStateMap = map[string]string{}
+	scanner := bufio.NewScanner(&outb)
+	firstRow := true
+	var columns []string
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+
+		if firstRow {
+			// save columns to use it later
+			columns = parts
+
+			if len(columns) > 2 && columns[0] == "UNIT" && columns[1] == "FILE" {
+				columns = append([]string{"UNIT FILE"}, columns[2:]...)
+			}
+
+			firstRow = false
+			continue
+		}
+
+		if len(parts) == 0 {
+			// payload finished
+			// need to exit the read loop
+			break
+		}
+
+		rowColumnsValues := map[string]string{}
+		for colIndex, colName := range columns {
+			// most likely impossible but still need to check the boundaries
+			if colIndex >= len(parts) {
+				break
+			}
+
+			// if column is the last - join all the data left in the row because it can contain spaces
+			if colIndex == len(columns)-1 {
+				rowColumnsValues[colName] = strings.Join(parts[colIndex:], " ")
+				break
+			}
+
+			rowColumnsValues[colName] = parts[colIndex]
+		}
+
+		servicesStateMap[rowColumnsValues["UNIT FILE"]] = rowColumnsValues["STATE"]
+	}
+	return servicesStateMap, nil
 }
 
 // ListSystemdServices list Systemd services via systemctl
-func ListSystemdServices() ([]SystemdService, error) {
+func ListSystemdServices(autostartOnly bool) ([]SystemdService, error) {
+	// get the map of unit files states to merge it with unit states
+	unitFilesStateByName, err := systemdUnitFilesState()
+	if err != nil {
+		return nil, err
+	}
+
 	cmd := exec.Command("systemctl",
 		"--type=service", // show only services(ignore .mount, .target, .path, .socket etc.)
 		"--all",          // show loaded but inactive services too
@@ -48,10 +120,10 @@ func ListSystemdServices() ([]SystemdService, error) {
 	var outb bytes.Buffer
 	cmd.Stdout = &outb
 	cmd.Stderr = &outb
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		errOutput, _ := ioutil.ReadAll(&outb)
-		return nil, fmt.Errorf("Systemctl: %s, %s", err.Error(), string(errOutput))
+		return nil, fmt.Errorf("Systemctl list-units: %s, %s", err.Error(), string(errOutput))
 	}
 
 	var services []SystemdService
@@ -97,12 +169,17 @@ func ListSystemdServices() ([]SystemdService, error) {
 			rowColumnsValues[colName] = parts[colIndex]
 		}
 
+		if autostartOnly && unitFilesStateByName[rowColumnsValues["UNIT"]] != "enabled" {
+			continue
+		}
+
 		services = append(services,
 			SystemdService{
 				UnitFile:    rowColumnsValues["UNIT"],
+				UnitState:   unitFilesStateByName[rowColumnsValues["UNIT"]],
 				LoadState:   rowColumnsValues["LOAD"],
 				ActiveState: rowColumnsValues["ACTIVE"],
-				SubState:    rowColumnsValues["SUB"],
+				State:       rowColumnsValues["SUB"],
 				Description: rowColumnsValues["DESCRIPTION"],
 			},
 		)
@@ -151,7 +228,7 @@ func ListSysVinitServices() ([]SysVService, error) {
 		}
 
 		services = append(services,
-			SysVService{UnitFile: parts[2], Status: state},
+			SysVService{UnitFile: parts[2], State: state},
 		)
 	}
 
@@ -190,10 +267,10 @@ func ListUpstartServices() ([]SysVService, error) {
 			continue
 		}
 
-		stateParts := strings.Split(parts[1], "/")
+		stateParts := strings.Split(strings.TrimSuffix(parts[1], ","), "/")
 
 		services = append(services,
-			SysVService{UnitFile: parts[0], Status: stateParts[1]},
+			SysVService{UnitFile: parts[0], State: stateParts[1]},
 		)
 	}
 
@@ -226,10 +303,10 @@ func setPathEnvVar(cmd *exec.Cmd) {
 	cmd.Env = append(cmd.Env, "PATH="+os.Getenv("PATH"))
 }
 
-func listSystemdServices() ([]map[string]string, error) {
+func listSystemdServices(autostartOnly bool) ([]map[string]string, error) {
 	var servicesList []map[string]string
 
-	services, err := ListSystemdServices()
+	services, err := ListSystemdServices(autostartOnly)
 	if err != nil {
 		return []map[string]string{}, err
 	}
@@ -240,7 +317,7 @@ func listSystemdServices() ([]map[string]string, error) {
 				"name":         service.UnitFile,
 				"load_state":   service.LoadState,
 				"active_state": service.ActiveState,
-				"sub_state":    service.SubState,
+				"state":        service.State,
 				"description":  service.Description,
 				"manager":      "systemd",
 			})
@@ -264,7 +341,7 @@ func listSysVAndUpstartServicesCombined() []map[string]string {
 	for _, service := range sysVServices {
 		servicesMap[service.UnitFile] = map[string]string{
 			"name":    service.UnitFile,
-			"status":  service.Status,
+			"status":  service.State,
 			"manager": "sysvinit",
 		}
 	}
@@ -282,7 +359,7 @@ func listSysVAndUpstartServicesCombined() []map[string]string {
 			// because it also contains services run under Upstart but with more accurate status
 			servicesMap[service.UnitFile] = map[string]string{
 				"name":    service.UnitFile,
-				"status":  service.Status,
+				"state":   service.State,
 				"manager": "upstart",
 			}
 		}
@@ -300,7 +377,7 @@ func listSysVAndUpstartServicesCombined() []map[string]string {
 }
 
 // ListServices detect the linux system manager and parse/combine results
-func ListServices() (map[string]interface{}, error) {
+func ListServices(autostartOnly bool) (map[string]interface{}, error) {
 	if runtime.GOOS != "linux" {
 		return nil, ErrorNotImplementedForOS
 	}
@@ -310,7 +387,7 @@ func ListServices() (map[string]interface{}, error) {
 
 	// first try to get Systemd services
 	if isSystemd() {
-		servicesList, err = listSystemdServices()
+		servicesList, err = listSystemdServices(autostartOnly)
 		if err != nil {
 			log.Errorf("[Services] Systemd appears running but failed to list a services: %s", err.Error())
 		} else {

--- a/pkg/monitoring/services/services_windows.go
+++ b/pkg/monitoring/services/services_windows.go
@@ -4,8 +4,10 @@ package services
 
 import (
 	"context"
-	"github.com/StackExchange/wmi"
+	"strings"
 	"time"
+
+	"github.com/StackExchange/wmi"
 )
 
 const serviceListTimeout = time.Second * 5
@@ -14,11 +16,13 @@ const serviceListTimeout = time.Second * 5
 var ErrorNotImplementedForOS error
 
 type Win32_Service struct {
-	Name        string
-	DisplayName string
-	StartMode   string
-	State       string
-	Status      string
+	Name             string
+	DisplayName      string
+	Description      string
+	StartMode        string
+	State            string
+	Status           string
+	DelayedAutoStart bool
 }
 
 // todo: move to the separate package when we will also move processes.go to the separate package
@@ -37,25 +41,40 @@ func wmiQueryWithContext(ctx context.Context, query string, dst interface{}, con
 }
 
 // ListServices parse Windows Service Manager
-func ListServices() (map[string]interface{}, error) {
+func ListServices(autostartOnly bool) (map[string]interface{}, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), serviceListTimeout)
 	defer cancel()
 
 	var wmiServices []Win32_Service
-	err := wmiQueryWithContext(ctx, "Select Name,DisplayName,StartMode,State,Status from Win32_Service", &wmiServices)
+	err := wmiQueryWithContext(ctx, "Select Name,DisplayName,Description,StartMode,State,State,DelayedAutoStart from Win32_Service", &wmiServices)
 	if err != nil {
 		return nil, err
 	}
 
-	var servicesList []map[string]string
+	var servicesList []map[string]interface{}
 	for _, wmiService := range wmiServices {
-		servicesList = append(servicesList, map[string]string{
-			"name":         wmiService.Name,
-			"display_name": wmiService.DisplayName,
-			"start":        wmiService.StartMode,
-			"state":        wmiService.State,
-			"status":       wmiService.Status,
-			"manager":      "windows",
+		var autoStart bool
+
+		if strings.HasPrefix(strings.ToLower(wmiService.StartMode), "auto") {
+			autoStart = true
+		}
+
+		if autostartOnly && !autoStart {
+			continue
+		}
+
+		if wmiService.DelayedAutoStart {
+			wmiService.StartMode = wmiService.StartMode + "_delayed"
+		}
+
+		servicesList = append(servicesList, map[string]interface{}{
+			"name":        wmiService.Name,
+			"description": wmiService.DisplayName + " " + wmiService.Description,
+			"start":       strings.ToLower(wmiService.StartMode),
+			"auto_start":  autoStart,
+			"state":       strings.ToLower(wmiService.State),
+			"status":      strings.ToLower(wmiService.Status),
+			"manager":     "windows",
 		})
 	}
 


### PR DESCRIPTION
To fulfill DEV-585 discussion.
- detect auto_start(*see notes below)
- show only autostarting service by default(discover_autostarting_services_only in config)
- use `state` field for all of system managers to make filtering in the UI easier
- query `delayed autostart` status on win
- make win values lowercase 

*auto_start detection
- On Windows they have the `run=auto`
- On Linux SystemD I'm filtering only __STATE=enabled__ services from `systemctl --type=service --all --no-pager --plain --output=json list-unit-files`
- TODO: SysVinit/upstart currently assuming all services as auto-start. Will need to solve this by parsing unit files or list&correlate symlinks from `/etc/rc*.d`