### PR TITLE
ignore failed processes, if we log the errors we get way too many errors

### DIFF
--- a/pkg/monitoring/top/top_nonwindows.go
+++ b/pkg/monitoring/top/top_nonwindows.go
@@ -54,14 +54,12 @@ func (t *Top) GetProcesses() ([]*ProcessInfo, error) {
 
 	lenTotal := len(ps)
 	result := make([]*ProcessInfo, 0, lenTotal)
-	count := 0
 	var pi *ProcessInfo
 	// Read loads collected in the background
 	for {
 		pi = <-results
 		result = append(result, pi)
-		count++
-		if count == lenTotal-skipped {
+		if len(result) == lenTotal-skipped {
 			break
 		}
 	}


### PR DESCRIPTION
Fix for #71 

Ignore the processes completely in case something goes wrong. Likely for short-lived processes