### PR TITLE
Deb/rpm and -t fixes

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -437,10 +437,10 @@ func handleFlagTest(testConfig bool, ca *cagent.Cagent) {
 	}
 
 	if runtime.GOOS == "windows" {
-		_ = sendSuccessNotification("Cagent connection test succeed", "")
+		_ = sendSuccessNotification("Cagent connection test succeeded", "")
 	}
 
-	fmt.Printf("HUB connection test succeed and credentials are correct!\n")
+	fmt.Printf("HUB connection test succeeded and credentials are correct!\n")
 	os.Exit(0)
 }
 

--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -379,10 +379,9 @@ func handleFlagServiceInstall(ca *cagent.Cagent, systemManager service.System, s
 
 	if ca.Config.HubURL == "" {
 		fmt.Printf(`*** Attention: 'hub_url' config param is empty.\n
-*** You need to put the right credentials from your Cloudradar account into the config and then restart the service\n\n`)
+*** You need to put the right credentials from your Cloudradar account into the config and then restart the service:\n\n`)
+		fmt.Printf("%s\n\n", getSystemMangerCommand(systemManager.String(), svcConfig.Name, "restart"))
 	}
-
-	fmt.Printf("Run this command to restart the service: %s\n\n", getSystemMangerCommand(systemManager.String(), svcConfig.Name, "restart"))
 
 	os.Exit(0)
 }

--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -375,13 +375,7 @@ func handleFlagServiceInstall(ca *cagent.Cagent, systemManager service.System, s
 	}
 
 	fmt.Printf("Log file located at: %s\n", ca.Config.LogFile)
-	fmt.Printf("Config file located at: %s\n", cfgPath)
-
-	if ca.Config.HubURL == "" {
-		fmt.Printf(`*** Attention: 'hub_url' config param is empty.\n
-*** You need to put the right credentials from your Cloudradar account into the config and then restart the service:\n\n`)
-		fmt.Printf("%s\n\n", getSystemMangerCommand(systemManager.String(), svcConfig.Name, "restart"))
-	}
+	fmt.Printf("Config file located at: %s\n\n", cfgPath)
 
 	os.Exit(0)
 }
@@ -432,6 +426,24 @@ func handleFlagTest(testConfig bool, ca *cagent.Cagent) {
 			_ = sendErrorNotification("Cagent connection test failed", err.Error())
 		}
 		fmt.Printf("Cagent HUB test failed: %s\n", err.Error())
+		systemService, err := getServiceFromFlags(ca, "", "")
+		if err != nil {
+			fmt.Printf("Failed to get system service: %s\n", err.Error())
+			os.Exit(1)
+		}
+
+		status, err := systemService.Status()
+		if err != nil {
+			// service seems not installed
+			// no need to show the tip on how to restart it
+			os.Exit(1)
+		}
+
+		systemManager := service.ChosenSystem()
+		if status == service.StatusRunning || status == service.StatusStopped {
+			fmt.Printf("Fix the config and then restart the service:\n%s\n\n", getSystemMangerCommand(systemManager.String(), svcConfig.Name, "restart"))
+		}
+
 		os.Exit(1)
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -56,13 +56,13 @@ func (ca *Cagent) initHubHTTPClient() {
 
 func (ca *Cagent) TestHub() error {
 	if ca.Config.HubURL == "" {
-		return fmt.Errorf("please set the hub_url config param")
+		return fmt.Errorf("please fill config with hub_url, hub_user and hub_password from your Cloudradar account")
 	}
 
 	var u *url.URL
 	var err error
 	if u, err = url.Parse(ca.Config.HubURL); err != nil {
-		return fmt.Errorf("can't parse hub_url: %s", err.Error())
+		return fmt.Errorf("can't parse hub_url: %s. Make sure to put the right params from your Cloudradar account", err.Error())
 	}
 
 	if u.Scheme != "http" && u.Scheme != "https" {


### PR DESCRIPTION
- Fix typo (succeed->succeeded)
- Show instruction on how to restart the service only in case there is an error and service is actually installed
- Improve the pkg installer output