### PR TITLE
improve docker missing error handling

### DIFF
--- a/cagent.go
+++ b/cagent.go
@@ -28,7 +28,7 @@ type Cagent struct {
 	fsWatcher            *FSWatcher
 	netWatcher           *NetWatcher
 	windowsUpdateWatcher *WindowsUpdateWatcher // nolint: structcheck,megacheck
-	docker               *docker.DockerWatcher
+	dockerWatcher        *docker.Watcher
 
 	vmstatLazyInit sync.Once
 	vmWatchers     map[string]vmstattypes.Provider
@@ -45,7 +45,7 @@ func New(cfg *Config, cfgPath string, version string) *Cagent {
 		ConfigLocation: cfgPath,
 		version:        version,
 		vmWatchers:     make(map[string]vmstattypes.Provider),
-		docker:         &docker.DockerWatcher{},
+		dockerWatcher:  &docker.Watcher{},
 	}
 
 	if rootCertsPath != "" {

--- a/cagent.go
+++ b/cagent.go
@@ -45,7 +45,14 @@ func New(cfg *Config, cfgPath string, version string) *Cagent {
 		ConfigLocation: cfgPath,
 		version:        version,
 		vmWatchers:     make(map[string]vmstattypes.Provider),
-		dockerWatcher:  &docker.Watcher{},
+	}
+
+	if dw, err := docker.New(); err != nil {
+		if err != docker.ErrorNotImplementedForOS {
+			log.Errorf("[docker] init error: %s", err)
+		}
+	} else {
+		ca.dockerWatcher = dw
 	}
 
 	if rootCertsPath != "" {

--- a/cagent.go
+++ b/cagent.go
@@ -45,6 +45,7 @@ func New(cfg *Config, cfgPath string, version string) *Cagent {
 		ConfigLocation: cfgPath,
 		version:        version,
 		vmWatchers:     make(map[string]vmstattypes.Provider),
+		docker:         &docker.DockerWatcher{},
 	}
 
 	if rootCertsPath != "" {

--- a/cagent.go
+++ b/cagent.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/docker"
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat"
 	vmstattypes "github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat/types"
 
@@ -27,9 +28,11 @@ type Cagent struct {
 	fsWatcher            *FSWatcher
 	netWatcher           *NetWatcher
 	windowsUpdateWatcher *WindowsUpdateWatcher // nolint: structcheck,megacheck
-	vmstatLazyInit       sync.Once
-	vmWatchers           map[string]vmstattypes.Provider
-	hwInventory          sync.Once
+	docker               *docker.DockerWatcher
+
+	vmstatLazyInit sync.Once
+	vmWatchers     map[string]vmstattypes.Provider
+	hwInventory    sync.Once
 
 	rootCAs *x509.CertPool
 

--- a/handler.go
+++ b/handler.go
@@ -17,7 +17,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/cloudradar-monitoring/cagent/pkg/hwinfo"
-	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/docker"
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/services"
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat"
 )
@@ -256,13 +255,15 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 
 	measurements = measurements.AddWithPrefix("services.", servicesList)
 
-	containersList, err := ca.dockerWatcher.ListContainers()
-	if err != nil && err != docker.ErrorNotImplementedForOS {
-		// no need to log because already done inside ListContainers()
-		errs = append(errs, err.Error())
-	}
+	if ca.dockerWatcher != nil {
+		containersList, err := ca.dockerWatcher.ListContainers()
+		if err != nil {
+			// no need to log because already done inside ListContainers()
+			errs = append(errs, err.Error())
+		}
 
-	measurements = measurements.AddWithPrefix("dockerWatcher.", containersList)
+		measurements = measurements.AddWithPrefix("dockerWatcher.", containersList)
+	}
 
 	if len(errs) == 0 {
 		measurements["cagent.success"] = 1

--- a/handler.go
+++ b/handler.go
@@ -256,7 +256,10 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 
 	measurements = measurements.AddWithPrefix("services.", servicesList)
 
-	containersList, err := docker.ListContainers()
+	if ca.docker == nil {
+		ca.docker = &docker.DockerWatcher{}
+	}
+	containersList, err := ca.docker.ListContainers()
 	if err != nil && err != docker.ErrorNotImplementedForOS {
 		// no need to log because already done inside ListContainers()
 		errs = append(errs, err.Error())

--- a/handler.go
+++ b/handler.go
@@ -256,13 +256,13 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 
 	measurements = measurements.AddWithPrefix("services.", servicesList)
 
-	containersList, err := ca.docker.ListContainers()
+	containersList, err := ca.dockerWatcher.ListContainers()
 	if err != nil && err != docker.ErrorNotImplementedForOS {
 		// no need to log because already done inside ListContainers()
 		errs = append(errs, err.Error())
 	}
 
-	measurements = measurements.AddWithPrefix("docker.", containersList)
+	measurements = measurements.AddWithPrefix("dockerWatcher.", containersList)
 
 	if len(errs) == 0 {
 		measurements["cagent.success"] = 1

--- a/handler.go
+++ b/handler.go
@@ -256,9 +256,6 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 
 	measurements = measurements.AddWithPrefix("services.", servicesList)
 
-	if ca.docker == nil {
-		ca.docker = &docker.DockerWatcher{}
-	}
 	containersList, err := ca.docker.ListContainers()
 	if err != nil && err != docker.ErrorNotImplementedForOS {
 		// no need to log because already done inside ListContainers()

--- a/pkg/monitoring/docker/docker.go
+++ b/pkg/monitoring/docker/docker.go
@@ -12,25 +12,36 @@ import (
 
 const dockerEndpointAddress = "unix:///var/run/docker.sock"
 
-var client *docker.Client
-var connectionSucceedOnce bool
+type DockerWatcher struct {
+	client                *docker.Client
+	connectionSucceedOnce bool
+}
 
-func ListContainers() (map[string]interface{}, error) {
-	var err error
-	if client == nil {
-		client, err = docker.NewClient(dockerEndpointAddress)
+func (dw *DockerWatcher) initClient() error {
+	if dw.client == nil {
+		_, err := docker.NewClient(dockerEndpointAddress)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
+	return nil
+}
+
+func (dw *DockerWatcher) ListContainers() (map[string]interface{}, error) {
+	err := dw.initClient()
+	if err != nil {
+		return nil, err
+	}
+
 	var dockerExecExists bool
 	if _, err := exec.LookPath("docker"); err == nil {
 		dockerExecExists = true
 	}
 
-	containers, err := client.ListContainers(docker.ListContainersOptions{All: false})
+	containers, err := dw.client.ListContainers(docker.ListContainersOptions{All: false})
 	if err != nil &&
-		!dockerExecExists && !connectionSucceedOnce &&
+		!dockerExecExists && // docker executable not exists in the system
+		!dw.connectionSucceedOnce && // connection with Docker via UNIX socket was never succeed in this session
 		(strings.Contains(err.Error(), "no such file or directory") || err == docker.ErrConnectionRefused) {
 
 		// do not produce error if Docker executable is missing and wasn't successfully connected in this session before
@@ -41,7 +52,7 @@ func ListContainers() (map[string]interface{}, error) {
 	}
 
 	// store ths to handle 'connection refused' as error afterwards
-	connectionSucceedOnce = true
+	dw.connectionSucceedOnce = true
 
 	var containersResults []map[string]interface{}
 	for _, container := range containers {
@@ -57,16 +68,13 @@ func ListContainers() (map[string]interface{}, error) {
 	return map[string]interface{}{"containers": containersResults}, nil
 }
 
-func ContainerNameByID(id string) (string, error) {
-	var err error
-	if client == nil {
-		client, err = docker.NewClient(dockerEndpointAddress)
-		if err != nil {
-			return "", err
-		}
+func (dw *DockerWatcher) ContainerNameByID(id string) (string, error) {
+	err := dw.initClient()
+	if err != nil {
+		return "", err
 	}
 
-	container, err := client.InspectContainer(id)
+	container, err := dw.client.InspectContainer(id)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/monitoring/docker/docker.go
+++ b/pkg/monitoring/docker/docker.go
@@ -35,14 +35,15 @@ func (dw *Watcher) ListContainers() (map[string]interface{}, error) {
 	}
 
 	containers, err := dw.client.ListContainers(docker.ListContainersOptions{All: false})
-	if err != nil &&
-		!dockerExecExists && // docker executable not exists in the system
-		!dw.connectionSucceedOnce && // connection with Docker via UNIX socket was never succeed in this session
-		(strings.Contains(err.Error(), "no such file or directory") || err == docker.ErrConnectionRefused) {
+	if err != nil {
+		if !dockerExecExists && // docker executable not exists in the system
+			!dw.connectionSucceedOnce && // connection with Docker via UNIX socket was never succeed in this session
+			(strings.Contains(err.Error(), "no such file or directory") || err == docker.ErrConnectionRefused) {
 
-		// do not produce error if Docker executable is missing and wasn't successfully connected in this session before
-		return nil, nil
-	} else if err != nil {
+			// do not produce error if Docker executable is missing and wasn't successfully connected in this session before
+			return nil, nil
+		}
+
 		log.Errorf("[Docker] Failed to list containers: %s", err.Error())
 		return nil, err
 	}

--- a/pkg/monitoring/docker/docker.go
+++ b/pkg/monitoring/docker/docker.go
@@ -3,7 +3,6 @@
 package docker
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 

--- a/pkg/monitoring/docker/docker.go
+++ b/pkg/monitoring/docker/docker.go
@@ -12,12 +12,12 @@ import (
 
 const dockerEndpointAddress = "unix:///var/run/docker.sock"
 
-type DockerWatcher struct {
+type Watcher struct {
 	client                *docker.Client
 	connectionSucceedOnce bool
 }
 
-func (dw *DockerWatcher) initClient() error {
+func (dw *Watcher) initClient() error {
 	if dw.client == nil {
 		_, err := docker.NewClient(dockerEndpointAddress)
 		if err != nil {
@@ -27,7 +27,7 @@ func (dw *DockerWatcher) initClient() error {
 	return nil
 }
 
-func (dw *DockerWatcher) ListContainers() (map[string]interface{}, error) {
+func (dw *Watcher) ListContainers() (map[string]interface{}, error) {
 	err := dw.initClient()
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (dw *DockerWatcher) ListContainers() (map[string]interface{}, error) {
 	return map[string]interface{}{"containers": containersResults}, nil
 }
 
-func (dw *DockerWatcher) ContainerNameByID(id string) (string, error) {
+func (dw *Watcher) ContainerNameByID(id string) (string, error) {
 	err := dw.initClient()
 	if err != nil {
 		return "", err

--- a/pkg/monitoring/docker/docker.go
+++ b/pkg/monitoring/docker/docker.go
@@ -12,27 +12,23 @@ import (
 
 const dockerEndpointAddress = "unix:///var/run/docker.sock"
 
+// Don't use this struct directly.
+// Use New() instead
 type Watcher struct {
 	client                *docker.Client
 	connectionSucceedOnce bool
 }
 
-func (dw *Watcher) initClient() error {
-	if dw.client == nil {
-		_, err := docker.NewClient(dockerEndpointAddress)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (dw *Watcher) ListContainers() (map[string]interface{}, error) {
-	err := dw.initClient()
+func New() (*Watcher, error) {
+	client, err := docker.NewClient(dockerEndpointAddress)
 	if err != nil {
 		return nil, err
 	}
 
+	return &Watcher{client: client}, nil
+}
+
+func (dw *Watcher) ListContainers() (map[string]interface{}, error) {
 	var dockerExecExists bool
 	if _, err := exec.LookPath("docker"); err == nil {
 		dockerExecExists = true
@@ -69,11 +65,6 @@ func (dw *Watcher) ListContainers() (map[string]interface{}, error) {
 }
 
 func (dw *Watcher) ContainerNameByID(id string) (string, error) {
-	err := dw.initClient()
-	if err != nil {
-		return "", err
-	}
-
 	container, err := dw.client.InspectContainer(id)
 	if err != nil {
 		return "", err

--- a/pkg/monitoring/docker/docker_windows.go
+++ b/pkg/monitoring/docker/docker_windows.go
@@ -4,6 +4,10 @@ package docker
 
 type Watcher struct{}
 
+func New() (*Watcher, error) {
+	return nil, ErrorNotImplementedForOS
+}
+
 func (_ *Watcher) ListContainers() (map[string]interface{}, error) {
 	return nil, ErrorNotImplementedForOS
 }

--- a/pkg/monitoring/docker/docker_windows.go
+++ b/pkg/monitoring/docker/docker_windows.go
@@ -2,12 +2,12 @@
 
 package docker
 
-type DockerWatcher struct{}
+type Watcher struct{}
 
-func (_ *DockerWatcher) ListContainers() (map[string]interface{}, error) {
+func (_ *Watcher) ListContainers() (map[string]interface{}, error) {
 	return nil, ErrorNotImplementedForOS
 }
 
-func (_ *DockerWatcher) ContainerNameByID(_ string) (string, error) {
+func (_ *Watcher) ContainerNameByID(_ string) (string, error) {
 	return "", ErrorNotImplementedForOS
 }

--- a/pkg/monitoring/docker/docker_windows.go
+++ b/pkg/monitoring/docker/docker_windows.go
@@ -2,10 +2,12 @@
 
 package docker
 
-func ListContainers() (map[string]interface{}, error) {
+type DockerWatcher struct{}
+
+func (_ *DockerWatcher) ListContainers() (map[string]interface{}, error) {
 	return nil, ErrorNotImplementedForOS
 }
 
-func ContainerNameByID(_ string) (string, error) {
+func (_ *DockerWatcher) ContainerNameByID(_ string) (string, error) {
 	return "", ErrorNotImplementedForOS
 }

--- a/processes.go
+++ b/processes.go
@@ -45,7 +45,7 @@ func (ca *Cagent) ProcessesResult() (m MeasurementsMap, err error) {
 	states := getPossibleProcStates()
 	var procs []ProcStat
 
-	procs, err = processes(ca.docker)
+	procs, err = processes(ca.dockerWatcher)
 	if err != nil {
 		log.Error("[PROC] error: ", err.Error())
 		return nil, err

--- a/processes.go
+++ b/processes.go
@@ -45,7 +45,7 @@ func (ca *Cagent) ProcessesResult() (m MeasurementsMap, err error) {
 	states := getPossibleProcStates()
 	var procs []ProcStat
 
-	procs, err = processes()
+	procs, err = processes(ca.docker)
 	if err != nil {
 		log.Error("[PROC] error: ", err.Error())
 		return nil, err

--- a/processes_notwindows.go
+++ b/processes_notwindows.go
@@ -30,7 +30,7 @@ type procStatus struct {
 
 var dockerContainerIDRE = regexp.MustCompile(`(?m)/docker/([a-f0-9]*)$`)
 
-func processes(dockerWatcher *docker.DockerWatcher) ([]ProcStat, error) {
+func processes(dockerWatcher *docker.Watcher) ([]ProcStat, error) {
 	if runtime.GOOS == "linux" {
 		return processesFromProc(dockerWatcher)
 	}
@@ -69,7 +69,7 @@ func getProcLongState(shortState byte) string {
 }
 
 // get process states from /proc/(pid)/stat
-func processesFromProc(dockerWatcher *docker.DockerWatcher) ([]ProcStat, error) {
+func processesFromProc(dockerWatcher *docker.Watcher) ([]ProcStat, error) {
 	filepaths, err := filepath.Glob(getHostProc() + "/[0-9]*/status")
 	if err != nil {
 		return nil, err

--- a/processes_notwindows.go
+++ b/processes_notwindows.go
@@ -30,9 +30,9 @@ type procStatus struct {
 
 var dockerContainerIDRE = regexp.MustCompile(`(?m)/docker/([a-f0-9]*)$`)
 
-func processes() ([]ProcStat, error) {
+func processes(dockerWatcher *docker.DockerWatcher) ([]ProcStat, error) {
 	if runtime.GOOS == "linux" {
-		return processesFromProc()
+		return processesFromProc(dockerWatcher)
 	}
 	return processesFromPS()
 }
@@ -69,7 +69,7 @@ func getProcLongState(shortState byte) string {
 }
 
 // get process states from /proc/(pid)/stat
-func processesFromProc() ([]ProcStat, error) {
+func processesFromProc(dockerWatcher *docker.DockerWatcher) ([]ProcStat, error) {
 	filepaths, err := filepath.Glob(getHostProc() + "/[0-9]*/status")
 	if err != nil {
 		return nil, err
@@ -112,19 +112,21 @@ func processesFromProc() ([]ProcStat, error) {
 			stat.Cmdline = strings.Replace(string(bytes.TrimRight(cmdline, "\x00")), "\x00", " ", -1)
 		}
 
-		cgroupFilepath := getHostProc() + "/" + pidString + "/cgroup"
-		cgroup, err := readProcFile(cgroupFilepath)
-		if err != nil && err != errorProcessTerminated {
-			log.Errorf("[PROC] failed to read cgroup(%s): %s", cgroupFilepath, err.Error())
-		} else if err == nil {
-			reParts := dockerContainerIDRE.FindStringSubmatch(string(cgroup))
-			if len(reParts) > 0 {
-				containerID := reParts[1]
-				containerName, err := docker.ContainerNameByID(containerID)
-				if err != nil && err != docker.ErrorNotImplementedForOS {
-					log.Errorf("[PROC] failed to read docker container name by id(%s): %s", containerID, err.Error())
-				} else {
-					stat.Container = containerName
+		if dockerWatcher != nil {
+			cgroupFilepath := getHostProc() + "/" + pidString + "/cgroup"
+			cgroup, err := readProcFile(cgroupFilepath)
+			if err != nil && err != errorProcessTerminated {
+				log.Errorf("[PROC] failed to read cgroup(%s): %s", cgroupFilepath, err.Error())
+			} else if err == nil {
+				reParts := dockerContainerIDRE.FindStringSubmatch(string(cgroup))
+				if len(reParts) > 0 {
+					containerID := reParts[1]
+					containerName, err := dockerWatcher.ContainerNameByID(containerID)
+					if err != nil && err != docker.ErrorNotImplementedForOS {
+						log.Errorf("[PROC] failed to read docker container name by id(%s): %s", containerID, err.Error())
+					} else {
+						stat.Container = containerName
+					}
 				}
 			}
 		}

--- a/processes_windows.go
+++ b/processes_windows.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/StackExchange/wmi"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/docker"
 )
 
 const processListTimeout = time.Second * 10
@@ -34,7 +36,7 @@ func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, con
 	}
 }
 
-func processes() ([]ProcStat, error) {
+func processes(_ *docker.DockerWatcher) ([]ProcStat, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), processListTimeout)
 	defer cancel()
 

--- a/processes_windows.go
+++ b/processes_windows.go
@@ -36,7 +36,7 @@ func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, con
 	}
 }
 
-func processes(_ *docker.DockerWatcher) ([]ProcStat, error) {
+func processes(_ *docker.Watcher) ([]ProcStat, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), processListTimeout)
 	defer cancel()
 


### PR DESCRIPTION
The check I have before was not enough, because for some cases docker lib returns the different error.
So the new plan is:
- check if executable `docker` is presented at `$PATH`. 
- If `docker` is not presented on system AND docker request wasn't successful within the session we can omit the error