### PR TITLE
Fix log dir/file perms

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -623,7 +623,7 @@ func configureLogger(ca *cagent.Cagent) {
 	log.SetFormatter(&tfmt)
 
 	if ca.Config.LogFile != "" {
-		if err := cagent.AddLogFileHook(ca.Config.LogFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644); err != nil {
+		if err := cagent.AddLogFileHook(ca.Config.LogFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666); err != nil {
 			log.Errorf("Failed to setup log file: %s: %s", ca.Config.PidFile, err.Error())
 		}
 	}

--- a/log.go
+++ b/log.go
@@ -49,7 +49,7 @@ type logrusFileHook struct {
 
 func AddLogFileHook(file string, flag int, chmod os.FileMode) error {
 	dir := filepath.Dir(file)
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0777)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to create the logs dir: '%s'", dir)
 	}


### PR DESCRIPTION
Make the auto-created log dir(`/var/log/cagent` on Linux) `777` perms and the log file itself `666`.
It will allow the case when the user removed the log file manually inside the dir that was created during the installation with `sudo` and then run `cagent` under unprivileged user