### PR TITLE
fix: hwinventory do not fail if DMI type not found

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,25 +2,6 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:6da51e5ec493ad2b44cb04129e2d0a068c8fb9bd6cb5739d199573558696bb94"
-  name = "github.com/Azure/go-ansiterm"
-  packages = [
-    ".",
-    "winterm",
-  ]
-  pruneopts = "UT"
-  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
-
-[[projects]]
-  digest = "1:f9ae348e1f793dcf9ed930ed47136a67343dbd6809c5c91391322267f4476892"
-  name = "github.com/Microsoft/go-winio"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "97e4973ce50b2ff5f09635a57e2b88a037aae829"
-  version = "v0.4.11"
-
-[[projects]]
   digest = "1:e92f5581902c345eb4ceffdcd4a854fb8f73cf436d47d837d1ec98ef1fe0a214"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
@@ -29,20 +10,12 @@
   version = "1.0.0"
 
 [[projects]]
-  digest = "1:98a97652081e7436576a129bbf9e1d6a20f8a884723cab8d2f1a8067e6822bc7"
+  digest = "1:3bed87a01c26940613570f2dbff778269df543755069d3dc65544bcdbd31002d"
   name = "github.com/cloudradar-monitoring/dmidecode"
   packages = ["."]
   pruneopts = "UT"
-  revision = "30327a83ffbd75afbc36f71f58f8b0834dfee292"
-  version = "0.0.3"
-
-[[projects]]
-  branch = "master"
-  digest = "1:e48c63e818c67fbf3d7afe20bba33134ab1a5bf384847385384fd027652a5a96"
-  name = "github.com/containerd/continuity"
-  packages = ["pathdriver"]
-  pruneopts = "UT"
-  revision = "004b46473808b3e7a4a3049c20e4376c91eb966d"
+  revision = "395107264116edf108cb35b42e1584412d37bf54"
+  version = "0.0.4"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -62,22 +35,6 @@
   pruneopts = "UT"
   revision = "39dc8486bd0952279431257138bc428275b86797"
   version = "v1.2.2"
-
-[[projects]]
-  digest = "1:d059a146ab350e553c2687d3e17f198eb5b27c7cf55fe6ba0e2d21349df63388"
-  name = "github.com/gogo/protobuf"
-  packages = ["proto"]
-  pruneopts = "UT"
-  revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
-  version = "v1.2.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:33f920ba428942560c22c0e145127dc09a52c52d64eac284daea6b0926fab0d1"
-  name = "github.com/ijc/Gotty"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "a8b993ba6abdb0e0c12b0125c603323a71c7790c"
 
 [[projects]]
   branch = "master"
@@ -121,33 +78,6 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
-
-[[projects]]
-  digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
-  name = "github.com/opencontainers/go-digest"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
-  version = "v1.0.0-rc1"
-
-[[projects]]
-  digest = "1:11db38d694c130c800d0aefb502fb02519e514dc53d9804ce51d1ad25ec27db6"
-  name = "github.com/opencontainers/image-spec"
-  packages = [
-    "specs-go",
-    "specs-go/v1",
-  ]
-  pruneopts = "UT"
-  revision = "d60099175f88c47cd379c4738d158884749ed235"
-  version = "v1.0.1"
-
-[[projects]]
-  digest = "1:38ee335aedf4626620f3cf8f605661e71abdcce7b40b38921962beb3980f0a20"
-  name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/user"]
-  pruneopts = "UT"
-  revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
-  version = "v0.1.1"
 
 [[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
@@ -262,8 +192,8 @@
     "github.com/go-ole/go-ole/oleutil",
     "github.com/kardianos/service",
     "github.com/lxn/walk",
-    "github.com/lxn/win",
     "github.com/lxn/walk/declarative",
+    "github.com/lxn/win",
     "github.com/pkg/errors",
     "github.com/shirou/gopsutil/cpu",
     "github.com/shirou/gopsutil/disk",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/cloudradar-monitoring/dmidecode"
-  version = "0.0.3"
+  version = "0.0.4"
 
 [[constraint]]
   name = "github.com/go-ole/go-ole"

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -44,7 +44,7 @@ func fetchInventory() (map[string]interface{}, error) {
 	res := make(map[string]interface{})
 
 	// all below requests are based on parsed data returned by dmidecode.Unmarshal
-	// refer to doc dmidecode.Get to get description of function behaviour
+	// refer to doc dmidecode.Get to get description of function behavior
 	var reqSys []dmidecode.ReqBaseBoard
 	if err = dmi.Get(&reqSys); err == nil {
 		res["baseboard.manufacturer"] = reqSys[0].Manufacturer

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -12,10 +12,11 @@ import (
 )
 
 func isCommandAvailable(name string) bool {
-	cmd := exec.Command("/bin/sh", "-c", "command -v "+name)
+	cmd := exec.Command("/bin/sh", "-c", "command", "-v", name)
 	if err := cmd.Run(); err != nil {
 		return false
 	}
+
 	return true
 }
 
@@ -42,45 +43,38 @@ func fetchInventory() (map[string]interface{}, error) {
 	res := make(map[string]interface{})
 
 	var reqSys []dmidecode.ReqBaseBoard
-	if err = dmi.Get(&reqSys); err != nil {
-		return nil, err
+	if err = dmi.Get(&reqSys); err == nil {
+		res["baseboard.manufacturer"] = reqSys[0].Manufacturer
+		res["baseboard.model"] = reqSys[0].Version
+		res["baseboard.serial_number"] = reqSys[0].SerialNumber
 	}
 
 	var reqMem []dmidecode.ReqPhysicalMemoryArray
-	if err = dmi.Get(&reqMem); err != nil {
-		return nil, err
+	if err = dmi.Get(&reqMem); err == nil {
+		res["ram.number_of_modules"] = reqMem[0].NumberOfDevices
 	}
 
 	var reqMemDevs []dmidecode.ReqMemoryDevice
-	if err = dmi.Get(&reqMemDevs); err != nil {
-		return nil, err
+	if err = dmi.Get(&reqMemDevs); err == nil {
+		for i := range reqMemDevs {
+			if reqMemDevs[i].Size == -1 {
+				continue
+			}
+			res[fmt.Sprintf("ram.%d.size_B", i)] = reqMemDevs[i].Size
+			res[fmt.Sprintf("ram.%d.type", i)] = reqMemDevs[i].Type
+		}
 	}
 
 	var reqCPU []dmidecode.ReqProcessor
-	if err = dmi.Get(&reqCPU); err != nil {
-		return nil, err
-	}
-
-	res["baseboard.manufacturer"] = reqSys[0].Manufacturer
-	res["baseboard.model"] = reqSys[0].Version
-	res["baseboard.serial_number"] = reqSys[0].SerialNumber
-
-	res["ram.number_of_modules"] = reqMem[0].NumberOfDevices
-	for i := range reqMemDevs {
-		if reqMemDevs[i].Size == -1 {
-			continue
+	if err = dmi.Get(&reqCPU); err == nil {
+		for i := range reqCPU {
+			res[fmt.Sprintf("cpu.%d.manufacturer", i)] = reqCPU[i].Manufacturer
+			res[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = reqCPU[i].Signature.String()
+			res[fmt.Sprintf("cpu.%d.description", i)] = reqCPU[i].Version
+			res[fmt.Sprintf("cpu.%d.core_count", i)] = reqCPU[i].CoreCount
+			res[fmt.Sprintf("cpu.%d.core_enabled", i)] = reqCPU[i].CoreEnabled
+			res[fmt.Sprintf("cpu.%d.thread_count", i)] = reqCPU[i].ThreadCount
 		}
-		res[fmt.Sprintf("ram.%d.size_B", i)] = reqMemDevs[i].Size
-		res[fmt.Sprintf("ram.%d.type", i)] = reqMemDevs[i].Type
-	}
-
-	for i := range reqCPU {
-		res[fmt.Sprintf("cpu.%d.manufacturer", i)] = reqCPU[i].Manufacturer
-		res[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = reqCPU[i].Signature.String()
-		res[fmt.Sprintf("cpu.%d.description", i)] = reqCPU[i].Version
-		res[fmt.Sprintf("cpu.%d.core_count", i)] = reqCPU[i].CoreCount
-		res[fmt.Sprintf("cpu.%d.core_enabled", i)] = reqCPU[i].CoreEnabled
-		res[fmt.Sprintf("cpu.%d.thread_count", i)] = reqCPU[i].ThreadCount
 	}
 
 	return res, nil

--- a/vendor/github.com/cloudradar-monitoring/dmidecode/dmidecode.go
+++ b/vendor/github.com/cloudradar-monitoring/dmidecode/dmidecode.go
@@ -153,7 +153,10 @@ func (dmi *DMI) Unmarshal(r io.Reader) error {
 }
 
 // Get by DMI key.
-// dst must be in form of *[]S where S is struct Req* from types.go
+// Unmarshal must be called prior to calling this function
+// dst must be in form of *[]S where S is struct Req* from types.go otherwise ErrPtrToSlice is returned
+// When function returns nil then dst contains slice with at least one valid entry
+// If key is not present in parse data ErrNotFound is returned
 func (dmi *DMI) Get(dst interface{}) error {
 	dv := reflect.ValueOf(dst)
 	if dv.Kind() != reflect.Ptr || dv.IsNil() {
@@ -168,7 +171,7 @@ func (dmi *DMI) Get(dst interface{}) error {
 
 	rec, present := dmi.decoded[reqType]
 	if !present {
-		return ErrNotFount
+		return ErrNotFound
 	}
 
 	// Initialize a slice with Count capacity

--- a/vendor/github.com/cloudradar-monitoring/dmidecode/types.go
+++ b/vendor/github.com/cloudradar-monitoring/dmidecode/types.go
@@ -62,7 +62,7 @@ const (
 var (
 	ErrPtrToSlice        = errors.New("dmidecode: parameter must be pointer to slice")
 	ErrInvalidEntityType = errors.New("dmidecode: invalid entity type")
-	ErrNotFount          = errors.New("dmidecode: not found")
+	ErrNotFound          = errors.New("dmidecode: DMI type not found")
 )
 
 type objType interface {


### PR DESCRIPTION
Some important DMI types like Base Board may be absent.
To fix continues inventory running even required fields are missing to gather as much information as possible