### PR TITLE
Improve WMI timeouts handling

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -273,9 +273,10 @@ func (ca *Cagent) CPUWatcher() *CPUWatcher {
 	// optimization to prevent CPU watcher to run in case CPU util metrics not are not needed
 	if len(ca.Config.CPUUtilTypes) > 0 && len(ca.Config.CPUUtilDataGather) > 0 || len(ca.Config.CPULoadDataGather) > 0 {
 		err := cw.Once()
+		_, isTimeoutError := err.(TimeoutError)
 		// if err is nil or we got timeout error - we should run the CPU Watcher continuously
 		// in case we go some other kind of error we shouldn't start the CPU watcher because WMI appears disabled on the system
-		if _, timeoutError := err.(TimeoutError); err == nil || timeoutError {
+		if err == nil || isTimeoutError {
 			go cw.Run()
 		}
 

--- a/processes_windows.go
+++ b/processes_windows.go
@@ -44,6 +44,9 @@ func processes(_ *docker.Watcher) ([]ProcStat, error) {
 
 	err := WMIQueryWithContext(ctx, `SELECT Name, CommandLine, ProcessID, ParentProcessId FROM Win32_Process`, &wmiProcs)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return nil, TimeoutError{"WMI query", processListTimeout}
+		}
 		return nil, errors.New("WMI query error: " + err.Error())
 	}
 

--- a/types.go
+++ b/types.go
@@ -39,6 +39,6 @@ type TimeoutError struct {
 	Timeout time.Duration
 }
 
-func (terr TimeoutError) Error() string {
-	return fmt.Sprintf("%s timeout after %.1fs", terr.Origin, terr.Timeout.Seconds())
+func (err TimeoutError) Error() string {
+	return fmt.Sprintf("%s timeout after %.1fs", err.Origin, err.Timeout.Seconds())
 }

--- a/types.go
+++ b/types.go
@@ -1,5 +1,10 @@
 package cagent
 
+import (
+	"fmt"
+	"time"
+)
+
 type MeasurementsMap map[string]interface{}
 
 func (mm MeasurementsMap) AddWithPrefix(prefix string, m MeasurementsMap) MeasurementsMap {
@@ -27,4 +32,13 @@ func floatToIntPercentRoundUP(f float64) int {
 
 func floatToIntRoundUP(f float64) int {
 	return int(f + 0.5)
+}
+
+type TimeoutError struct {
+	Origin  string
+	Timeout time.Duration
+}
+
+func (terr TimeoutError) Error() string {
+	return fmt.Sprintf("%s timeout after %.1fs", terr.Origin, terr.Timeout.Seconds())
 }


### PR DESCRIPTION
- do not stop the CPU watcher if 1st query returns timeout
- change `cpuGetUtilisationTimeout` and `measureInterval` for 20 seconds
- return better human-readable error instead of `context deadline exceeded` for WMI queries in CPU and win processes list