### PR TITLE
fix instruction for build from sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 - [Install Golang 1.9 or newer](https://golang.org/dl/)
 ```bash
 go get -d -u github.com/cloudradar-monitoring/cagent
-go build -o -ldflags="-X main.version=$(git --git-dir=src/github.com/cloudradar-monitoring/cagent/.git describe --always --long --dirty --tag)" cagent github.com/cloudradar-monitoring/cagent/cmd/cagent
+go build -o cagent -ldflags="-X main.version=$(git --git-dir=$GOPATH/src/github.com/cloudradar-monitoring/cagent/.git describe --always --long --dirty --tag)" github.com/cloudradar-monitoring/cagent/cmd/cagent
 ```
 
 ## How to run


### PR DESCRIPTION
after parameter -o must be filename
add $GOPATH in parameter git-dir for using relative path