### PR TITLE
Fix division by zero

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -171,6 +171,11 @@ func (tsa *TimeSeriesAverage) Percentage() (map[int]ValuesMap, error) {
 					count++
 				}
 
+				if count == 0 { // no metrics collected for last d minutes
+					sum[d][key] = -1
+					continue
+				}
+
 				// found the average for all collected measurements for the last d minutes
 				sum[d][key] = roundUpWithPrecision(valSum/float64(count), 2)
 			} else {


### PR DESCRIPTION
Fixing faulty values for CPU utilization:
```
  "cpu.util.idle.1.cpu0": -92233720368547760,
  "cpu.util.idle.1.cpu1": -92233720368547760,
  "cpu.util.user.1.cpu0": -92233720368547760,
  "cpu.util.user.1.cpu1": -92233720368547760,
  "cpu.util.idle.1.total": -92233720368547760,
  "cpu.util.user.1.total": -92233720368547760,
  "cpu.util.system.1.cpu0": -92233720368547760,
  "cpu.util.system.1.cpu1": -92233720368547760,
  "cpu.util.system.1.total": -92233720368547760,
```

It seems that when throttling CPU (using cpuburn for example), cagent get WMI query timeouts. This causes time series for cpu.util metrics for last time interval (d) to become empty (tsa.TimeSeries)