### PR TITLE
Fix nil WMI fields

### DIFF
--- a/pkg/hwinfo/hwinfo_windows.go
+++ b/pkg/hwinfo/hwinfo_windows.go
@@ -52,6 +52,7 @@ type win32_Processor struct {
 	NumberOfCores             *uint32
 	NumberOfEnabledCore       *uint32
 	NumberOfLogicalProcessors *uint32
+
 	/*
 		Possible fields so we could use them later if we will need
 
@@ -166,7 +167,6 @@ func fetchInventory() (map[string]interface{}, error) {
 	for i := range ram {
 		res[fmt.Sprintf("ram.%d.size_B", i)] = ram[i].Capacity
 		memoryType := ram[i].MemoryType
-
 		if memoryType == nil {
 			res[fmt.Sprintf("ram.%d.type", i)] = nil
 		} else {

--- a/pkg/hwinfo/hwinfo_windows.go
+++ b/pkg/hwinfo/hwinfo_windows.go
@@ -17,7 +17,7 @@ const reqTimeout = time.Second * 10
 
 type win32_PhysicalMemory struct {
 	Capacity   *uint64
-	MemoryType winMemoryType
+	MemoryType *winMemoryType
 
 	/*
 		Possible fields so we could use them later if we will need
@@ -165,7 +165,13 @@ func fetchInventory() (map[string]interface{}, error) {
 	res["ram.number_of_modules"] = len(ram)
 	for i := range ram {
 		res[fmt.Sprintf("ram.%d.size_B", i)] = ram[i].Capacity
-		res[fmt.Sprintf("ram.%d.type", i)] = ram[i].MemoryType.String()
+		memoryType := ram[i].MemoryType
+
+		if memoryType == nil {
+			res[fmt.Sprintf("ram.%d.type", i)] = nil
+		} else {
+			res[fmt.Sprintf("ram.%d.type", i)] = (*memoryType).String()
+		}
 	}
 
 	return res, nil

--- a/pkg/hwinfo/hwinfo_windows.go
+++ b/pkg/hwinfo/hwinfo_windows.go
@@ -16,42 +16,51 @@ type winMemoryType uint16
 const reqTimeout = time.Second * 10
 
 type win32_PhysicalMemory struct {
-	BankLabel     string
-	Capacity      uint64
-	DataWidth     uint16
-	DeviceLocator string
-	InstallDate   *time.Time
-	Manufacturer  *string
-	MaxVoltage    *uint32
-	MinVoltage    *uint32
-	MemoryType    winMemoryType
-	Model         *string
-	PartNumber    *string
-	SerialNumber  *string
-	Speed         uint32
-	Status        *string
-	TotalWidth    *uint16
+	Capacity   *uint64
+	MemoryType winMemoryType
+
+	/*
+		Possible fields so we could use them later if we will need
+
+		BankLabel     *string
+		DataWidth     *uint16
+		DeviceLocator *string
+		InstallDate   *time.Time
+		Manufacturer  *string
+		MaxVoltage    *uint32
+		MinVoltage    *uint32
+		Model         *string
+		PartNumber    *string
+		SerialNumber  *string
+		Speed         *uint32
+		Status        *string
+		TotalWidth    *uint16
+	*/
 }
 
 type win32_BaseBoard struct {
-	Manufacturer string
+	Manufacturer *string
 	Product      *string
 	Model        *string
-	SerialNumber string
+	SerialNumber *string
 }
 
 type win32_Processor struct {
-	DeviceID                  *string
-	Description               string
-	Name                      string
-	Manufacturer              string
-	SerialNumber              string
-	SocketDesignation         string
-	MaxClockSpeed             uint32
-	NumberOfCores             uint32
-	NumberOfEnabledCore       uint32
-	NumberOfLogicalProcessors uint32
-	ProcessorType             uint16
+	Description               *string
+	Name                      *string
+	Manufacturer              *string
+	NumberOfCores             *uint32
+	NumberOfEnabledCore       *uint32
+	NumberOfLogicalProcessors *uint32
+	/*
+		Possible fields so we could use them later if we will need
+
+		DeviceID                  *string
+		SerialNumber              *string
+		SocketDesignation         *string
+		MaxClockSpeed             *uint32
+		ProcessorType             *uint16
+	*/
 }
 
 func (w winMemoryType) String() string {
@@ -139,6 +148,7 @@ func fetchInventory() (map[string]interface{}, error) {
 	res["baseboard.manufacturer"] = baseBoard[0].Manufacturer
 	res["baseboard.serial_number"] = baseBoard[0].SerialNumber
 	if baseBoard[0].Product != nil {
+		res["baseboard.model"] = baseBoard[0].Product
 		res["baseboard.model"] = baseBoard[0].Product
 	}
 

--- a/pkg/hwinfo/hwinfo_windows.go
+++ b/pkg/hwinfo/hwinfo_windows.go
@@ -148,10 +148,7 @@ func fetchInventory() (map[string]interface{}, error) {
 
 	res["baseboard.manufacturer"] = baseBoard[0].Manufacturer
 	res["baseboard.serial_number"] = baseBoard[0].SerialNumber
-	if baseBoard[0].Product != nil {
-		res["baseboard.model"] = baseBoard[0].Product
-		res["baseboard.model"] = baseBoard[0].Product
-	}
+	res["baseboard.model"] = baseBoard[0].Product
 
 	var ram []win32_PhysicalMemory
 	query = wmi.CreateQuery(&ram, "")


### PR DESCRIPTION
When doing WMI queries some fields may be missing on some systems. WMI returns nil for them, but the `github.com/StackExchange/wmi` lib we are using is failing to set the struct field because it is not a pointer but just the value and we got all the query failed even if it just 1/999 process which has a nil value. So...

- Let's make all the fields pointers
- Check for nil if we need to make some operations on the value

Also, I made some optimization in hwinfo. I have commented out all the unused fields so the WMI query could become faster and less memory consuming