### PR TITLE
Fix package naming according to Go guidelines

### DIFF
--- a/cagent.go
+++ b/cagent.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/docker"
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat"
-	vmstattypes "github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat/types"
+	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat/types"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -33,7 +33,7 @@ type Cagent struct {
 	dockerWatcher        *docker.Watcher
 
 	vmstatLazyInit sync.Once
-	vmWatchers     map[string]vmstattypes.Provider
+	vmWatchers     map[string]types.Provider
 	hwInventory    sync.Once
 
 	rootCAs *x509.CertPool
@@ -46,7 +46,7 @@ func New(cfg *Config, cfgPath string, version string) *Cagent {
 		Config:         cfg,
 		ConfigLocation: cfgPath,
 		version:        version,
-		vmWatchers:     make(map[string]vmstattypes.Provider),
+		vmWatchers:     make(map[string]types.Provider),
 		dockerWatcher:  &docker.Watcher{},
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/docker"
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/services"
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat"
-	vmstattypes "github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat/types"
+	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat/types"
 )
 
 var ErrorTestWinUISettingsAreEmpty = errors.New("Please fill 'HUB URL', 'HUB USER' and 'HUB PASSWORD' from your Cloudradar account")
@@ -388,7 +388,7 @@ func (ca *Cagent) getVMStatMeasurements(f func(string, MeasurementsMap, error)) 
 		for _, name := range ca.Config.VirtualMachinesStat {
 			vm, err := vmstat.Acquire(name)
 			if err != nil {
-				if err != vmstattypes.ErrNotAvailable {
+				if err != types.ErrNotAvailable {
 					log.Warnf("vmstat: Error while acquiring vm provider \"%s\": %s", name, err.Error())
 				}
 			} else {

--- a/pkg/monitoring/vmstat/hyperv/provider_windows.go
+++ b/pkg/monitoring/vmstat/hyperv/provider_windows.go
@@ -16,9 +16,9 @@ type impl struct {
 	watcher *perfcounters.WinPerfCountersWatcher
 }
 
-var _ vmstattypes.Provider = (*impl)(nil)
+var _ types.Provider = (*impl)(nil)
 
-func New() vmstattypes.Provider {
+func New() types.Provider {
 	return &impl{
 		watcher: monitoring.GetWatcher(),
 	}
@@ -46,11 +46,11 @@ func (im *impl) Name() string {
 func (im *impl) IsAvailable() error {
 	st, err := wmiutil.CheckOptionalFeatureStatus(wmiutil.FeatureMicrosoftHyperV)
 	if err != nil {
-		return fmt.Errorf("%s %s", vmstattypes.ErrCheck.Error(), err.Error())
+		return fmt.Errorf("%s %s", types.ErrCheck.Error(), err.Error())
 	}
 
 	if st != wmiutil.FeatureInstallStateEnabled {
-		return vmstattypes.ErrNotAvailable
+		return types.ErrNotAvailable
 	}
 
 	return nil

--- a/pkg/monitoring/vmstat/types/types.go
+++ b/pkg/monitoring/vmstat/types/types.go
@@ -1,4 +1,4 @@
-package vmstattypes
+package types
 
 import (
 	"errors"

--- a/pkg/monitoring/vmstat/vmstat.go
+++ b/pkg/monitoring/vmstat/vmstat.go
@@ -8,7 +8,7 @@ import (
 )
 
 type provEntry struct {
-	prov vmstattypes.Provider
+	prov types.Provider
 	wg   sync.WaitGroup
 	run  sync.Once
 }
@@ -26,12 +26,12 @@ func init() {
 	}
 }
 
-func RegisterVMProvider(p vmstattypes.Provider) error {
+func RegisterVMProvider(p types.Provider) error {
 	providers.lock.Lock()
 	defer providers.lock.Unlock()
 
 	if _, ok := providers.pr[p.Name()]; ok {
-		return fmt.Errorf("%s: %s", vmstattypes.ErrAlreadyExists.Error(), p.Name())
+		return fmt.Errorf("%s: %s", types.ErrAlreadyExists.Error(), p.Name())
 	}
 
 	providers.pr[p.Name()] = &provEntry{prov: p}
@@ -39,7 +39,7 @@ func RegisterVMProvider(p vmstattypes.Provider) error {
 	return nil
 }
 
-func Acquire(name string) (vmstattypes.Provider, error) {
+func Acquire(name string) (types.Provider, error) {
 	providers.lock.Lock()
 	defer providers.lock.Unlock()
 
@@ -48,7 +48,7 @@ func Acquire(name string) (vmstattypes.Provider, error) {
 
 		entry.run.Do(func() {
 			if err = entry.prov.IsAvailable(); err != nil {
-				err = vmstattypes.ErrNotAvailable
+				err = types.ErrNotAvailable
 				return
 			}
 
@@ -65,10 +65,10 @@ func Acquire(name string) (vmstattypes.Provider, error) {
 		return entry.prov, nil
 	}
 
-	return nil, vmstattypes.ErrNotRegistered
+	return nil, types.ErrNotRegistered
 }
 
-func Release(p vmstattypes.Provider) error {
+func Release(p types.Provider) error {
 	providers.lock.Lock()
 	defer providers.lock.Unlock()
 
@@ -77,10 +77,10 @@ func Release(p vmstattypes.Provider) error {
 		return nil
 	}
 
-	return vmstattypes.ErrNotRegistered
+	return types.ErrNotRegistered
 }
 
-func IterateRegistered(f func(string, vmstattypes.Provider) bool) {
+func IterateRegistered(f func(string, types.Provider) bool) {
 	providers.lock.Lock()
 	defer providers.lock.Unlock()
 


### PR DESCRIPTION
package name for pkg/monitoring/vmstat/types/types.go was non-conforming to Go guidelines, forcing us to specify the package name explicitly to pass GolangCI checks.