### PR TITLE
Change severity level of log message when RAID stats is not available

### DIFF
--- a/raid.go
+++ b/raid.go
@@ -121,8 +121,7 @@ func (ar RaidArrays) Measurements() MeasurementsMap {
 
 func (ca *Cagent) RaidState() (MeasurementsMap, error) {
 	if _, err := os.Stat("/proc/mdstat"); os.IsNotExist(err) {
-		log.Error("[RAID] /proc/mdstat is missing")
-		// do not return error if mdstat is missing
+		log.Debugf("[RAID] /proc/mdstat is missing. Raid inspection disabled.")
 		return nil, nil
 	}
 


### PR DESCRIPTION
It was printing error message, but actually this is not an error.