### PR TITLE
Eliminate wmi query for process list

### DIFF
--- a/pkg/winapi/facade.go
+++ b/pkg/winapi/facade.go
@@ -1,0 +1,86 @@
+// +build windows
+
+package winapi
+
+import (
+	"reflect"
+	"unicode/utf16"
+	"unsafe"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// http://terminus.rewolf.pl/terminus/structures/ntdll/_PEB_combined.html
+	processParametersAddrOffsetInPEB64bit = uintptr(0x20)
+
+	// http://terminus.rewolf.pl/terminus/structures/ntdll/_RTL_USER_PROCESS_PARAMETERS_combined.html
+	commandLineAddrOffsetInRTLUserProcessParameters64bit = uintptr(0x70)
+)
+
+// GetProcessCommandLine to read process memory structure called PEB
+// https://docs.microsoft.com/en-us/windows/desktop/api/winternl/ns-winternl-_peb
+// it refers to RTL_USER_PROCESS_PARAMETERS structure, which contains command line string for the process
+// https://docs.microsoft.com/ru-ru/windows/desktop/api/winternl/ns-winternl-_rtl_user_process_parameters
+func GetProcessCommandLine(pid uint32) (string, error) {
+	handle, err := windows.OpenProcess(systemProcessAllAccess, false, pid)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err := windows.CloseHandle(handle)
+		if err != nil {
+			log.Warnf("winapi: there was error closing process handle: %s", err)
+		}
+	}()
+
+	pbi, err := GetProcessBasicInformation(handle)
+	if err != nil {
+		return "", err
+	}
+
+	if pbi.PebBaseAddress == 0 {
+		// it means that we are running as 32-bit process under WOW64 and pid belongs to the 64-bit process
+		return "", nil
+	}
+
+	var rtlUserProcessParametersAddr uintptr
+	_, err = ReadProcessMemory(
+		handle,
+		uintptr(pbi.PebBaseAddress)+processParametersAddrOffsetInPEB64bit,
+		uintptr(unsafe.Pointer(&rtlUserProcessParametersAddr)),
+		unsafe.Sizeof(rtlUserProcessParametersAddr),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	var externalCommandLine unicodeString
+	_, err = ReadProcessMemory(
+		handle,
+		rtlUserProcessParametersAddr+commandLineAddrOffsetInRTLUserProcessParameters64bit,
+		uintptr(unsafe.Pointer(&externalCommandLine)),
+		unsafe.Sizeof(externalCommandLine),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	buffer := make([]uint16, externalCommandLine.Length, externalCommandLine.MaximumLength)
+	_, err = ReadProcessMemory(
+		handle,
+		uintptr(unsafe.Pointer(externalCommandLine.BufferAddr)),
+		uintptr(unsafe.Pointer(&buffer[0])),
+		uintptr(externalCommandLine.Length),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&buffer))
+	hdr.Len = int(externalCommandLine.Length / 2)
+	hdr.Cap = int(externalCommandLine.MaximumLength / 2)
+
+	return string(utf16.Decode(buffer)), nil
+}

--- a/pkg/winapi/types.go
+++ b/pkg/winapi/types.go
@@ -1,0 +1,135 @@
+// +build windows
+
+package winapi
+
+import (
+	"reflect"
+	"unicode/utf16"
+	"unsafe"
+)
+
+const (
+	HundredNSToTick = 0.0000001
+
+	// systemProcessorPerformanceInformationClass information class to query with NTQuerySystemInformation()
+	// https://processhacker.sourceforge.io/doc/ntexapi_8h.html#ad5d815b48e8f4da1ef2eb7a2f18a54e0
+	systemProcessorPerformanceInformationClass = 8
+	systemProcessorPerformanceInfoSize         = unsafe.Sizeof(SystemProcessorPerformanceInformation{})
+
+	// systemProcessInformationClass class to query with NTQuerySystemInformation()
+	// https://docs.microsoft.com/en-us/windows/desktop/api/winternl/nf-winternl-ntquerysysteminformation#system_process_information
+	systemProcessInformationClass = 5
+	systemProcessInfoSize         = unsafe.Sizeof(SystemProcessInformation{})
+	systemThreadInfoSize          = unsafe.Sizeof(systemThreadInformation{})
+
+	// systemProcessAllAccess class to query with OpenProcess()
+	// https://docs.microsoft.com/ru-ru/windows/desktop/ProcThread/process-security-and-access-rights
+	systemProcessAllAccess = 0x1F0FFF
+
+	// systemProcessBasicInformationClass class to query with NtQueryInformationProcess
+	// returns PROCESS_BASIC_INFORMATION struct
+	systemProcessBasicInformationClass = 0
+	systemProcessBasicInformationSize  = unsafe.Sizeof(processBasicInformation{})
+)
+
+// SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION
+// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/processor_performance.htm
+type SystemProcessorPerformanceInformation struct {
+	IdleTime       int64 // idle time in 100ns (this is not a filetime).
+	KernelTime     int64 // kernel time in 100ns.  kernel time includes idle time. (this is not a filetime).
+	UserTime       int64 // usertime in 100ns (this is not a filetime).
+	DpcTime        int64 // dpc time in 100ns (this is not a filetime).
+	InterruptTime  int64 // interrupt time in 100ns
+	InterruptCount uint32
+}
+
+// KPRIORITY
+type kPriority int32
+
+// UNICODE_STRING
+type unicodeString struct {
+	Length        uint16
+	MaximumLength uint16
+	BufferAddr    *uint16
+}
+
+func (u unicodeString) String() string {
+	var s []uint16
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	hdr.Data = uintptr(unsafe.Pointer(u.BufferAddr))
+	hdr.Len = int(u.Length / 2)
+	hdr.Cap = int(u.MaximumLength / 2)
+	return string(utf16.Decode(s))
+}
+
+// SYSTEM_PROCESS_INFORMATION
+type SystemProcessInformation struct {
+	NextEntryOffset              uint32        // ULONG
+	NumberOfThreads              uint32        // ULONG
+	WorkingSetPrivateSize        int64         // LARGE_INTEGER
+	HardFaultCount               uint32        // ULONG
+	NumberOfThreadsHighWatermark uint32        // ULONG
+	CycleTime                    uint64        // ULONGLONG
+	CreateTime                   int64         // LARGE_INTEGER
+	UserTime                     int64         // LARGE_INTEGER
+	KernelTime                   int64         // LARGE_INTEGER
+	ImageName                    unicodeString // UNICODE_STRING
+	BasePriority                 kPriority     // KPRIORITY
+	UniqueProcessId              uintptr       // HANDLE
+	InheritedFromUniqueProcessId uintptr       // HANDLE
+	HandleCount                  uint32        // ULONG
+	SessionId                    uint32        // ULONG
+	UniqueProcessKey             *uint32       // ULONG_PTR
+	PeakVirtualSize              uintptr       // SIZE_T
+	VirtualSize                  uintptr       // SIZE_T
+	PageFaultCount               uint32        // ULONG
+	PeakWorkingSetSize           uintptr       // SIZE_T
+	WorkingSetSize               uintptr       // SIZE_T
+	QuotaPeakPagedPoolUsage      uintptr       // SIZE_T
+	QuotaPagedPoolUsage          uintptr       // SIZE_T
+	QuotaPeakNonPagedPoolUsage   uintptr       // SIZE_T
+	QuotaNonPagedPoolUsage       uintptr       // SIZE_T
+	PagefileUsage                uintptr       // SIZE_T
+	PeakPagefileUsage            uintptr       // SIZE_T
+	PrivatePageCount             uintptr       // SIZE_T
+	ReadOperationCount           int64         // LARGE_INTEGER
+	WriteOperationCount          int64         // LARGE_INTEGER
+	OtherOperationCount          int64         // LARGE_INTEGER
+	ReadTransferCount            int64         // LARGE_INTEGER
+	WriteTransferCount           int64         // LARGE_INTEGER
+	OtherTransferCount           int64         // LARGE_INTEGER
+}
+
+// KWAIT_REASON
+type kWaitReason int32
+
+// CLIENT_ID
+type clientID struct {
+	UniqueProcess uintptr // HANDLE
+	UniqueThread  uintptr // HANDLE
+}
+
+// SYSTEM_THREAD_INFORMATION
+type systemThreadInformation struct {
+	KernelTime      int64       // LARGE_INTEGER
+	UserTime        int64       // LARGE_INTEGER
+	CreateTime      int64       // LARGE_INTEGER
+	WaitTime        uint32      // ULONG
+	StartAddress    uintptr     // PVOID
+	ClientId        clientID    // CLIENT_ID
+	Priority        kPriority   // KPRIORITY
+	BasePriority    int32       // LONG
+	ContextSwitches uint32      // ULONG
+	ThreadState     uint32      // ULONG
+	WaitReason      kWaitReason // KWAIT_REASON
+}
+
+// PROCESS_BASIC_INFORMATION
+type processBasicInformation struct {
+	ExitStatus                   uintptr
+	PebBaseAddress               uintptr
+	AffinityMask                 uintptr
+	BasePriority                 int32
+	UniqueProcessID              uintptr
+	InheritedFromUniqueProcessId uintptr
+}

--- a/pkg/winapi/winapi.go
+++ b/pkg/winapi/winapi.go
@@ -183,12 +183,11 @@ func GetProcessBasicInformation(processHandle windows.Handle) (*processBasicInfo
 }
 
 func ReadProcessMemory(processHandle windows.Handle, srcAddr uintptr, dstAddr uintptr, size uintptr) (int, error) {
-	var nBytesRead int
-
 	if err := checkKernel32ProceduresAvailable(); err != nil {
-		return nBytesRead, err
+		return 0, err
 	}
 
+	var nBytesRead int
 	retCode, _, err := procReadProcessMemory.Call(
 		uintptr(processHandle),
 		srcAddr,

--- a/pkg/winapi/winapi.go
+++ b/pkg/winapi/winapi.go
@@ -4,147 +4,62 @@ package winapi
 
 import (
 	"fmt"
+	"unsafe"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
-	"reflect"
-	"unicode/utf16"
-	"unsafe"
-)
-
-const (
-	HundredNSToTick = 0.0000001
-
-	// systemProcessorPerformanceInformationClass information class to query with NTQuerySystemInformation
-	// https://processhacker.sourceforge.io/doc/ntexapi_8h.html#ad5d815b48e8f4da1ef2eb7a2f18a54e0
-	systemProcessorPerformanceInformationClass = 8
-	systemProcessorPerformanceInfoSize         = uint32(unsafe.Sizeof(SystemProcessorPerformanceInformation{}))
-
-	// systemProcessInformationClass class to query with NTQuerySystemInformation
-	// https://docs.microsoft.com/en-us/windows/desktop/api/winternl/nf-winternl-ntquerysysteminformation#system_process_information
-	systemProcessInformationClass = 5
-	systemProcessInfoSize         = uint32(unsafe.Sizeof(SystemProcessInformation{}))
-	systemThreadInfoSize          = uint32(unsafe.Sizeof(systemThreadInformation{}))
 )
 
 var (
 	ntDLL        = windows.NewLazySystemDLL("Ntdll.dll")
-	ntDLLLoadErr = ntDLL.Load() // attempt to load the system dll and store the err for reference
+	ntDLLLoadErr = ntDLL.Load()
 
-	// Windows API Proc
+	kernel32DLL    = windows.NewLazySystemDLL("kernel32.dll")
+	kernel32DLLErr = kernel32DLL.Load()
+
 	// https://docs.microsoft.com/en-us/windows/desktop/api/winternl/nf-winternl-ntquerysysteminformation
 	procNtQuerySystemInformation        = ntDLL.NewProc("NtQuerySystemInformation")
-	procNtQuerySystemInformationLoadErr = procNtQuerySystemInformation.Find() // attempt to find the proc and store the error if needed
+	procNtQuerySystemInformationLoadErr = procNtQuerySystemInformation.Find()
+
+	// https://docs.microsoft.com/ru-ru/windows/desktop/api/winternl/nf-winternl-ntqueryinformationprocess
+	procNtQueryInformationProcess        = ntDLL.NewProc("NtQueryInformationProcess")
+	procNtQueryInformationProcessLoadErr = procNtQueryInformationProcess.Find()
+
+	// https://docs.microsoft.com/en-us/windows/desktop/api/memoryapi/nf-memoryapi-readprocessmemory
+	procReadProcessMemory        = kernel32DLL.NewProc("ReadProcessMemory")
+	procReadProcessMemoryLoadErr = procReadProcessMemory.Find()
 )
-
-// SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION
-// defined in windows api doc with the following
-// https://docs.microsoft.com/en-us/windows/desktop/api/winternl/nf-winternl-ntquerysysteminformation#system_processor_performance_information
-// additional fields documented here
-// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/processor_performance.htm
-type SystemProcessorPerformanceInformation struct {
-	IdleTime       int64 // idle time in 100ns (this is not a filetime).
-	KernelTime     int64 // kernel time in 100ns.  kernel time includes idle time. (this is not a filetime).
-	UserTime       int64 // usertime in 100ns (this is not a filetime).
-	DpcTime        int64 // dpc time in 100ns (this is not a filetime).
-	InterruptTime  int64 // interrupt time in 100ns
-	InterruptCount uint32
-}
-
-// KPRIORITY
-type kPriority int32
-
-// UNICODE_STRING
-type unicodeString struct {
-	Length        uint16
-	MaximumLength uint16
-	Buffer        *uint16
-}
-
-func (u unicodeString) String() string {
-	var s []uint16
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-	hdr.Data = uintptr(unsafe.Pointer(u.Buffer))
-	hdr.Len = int(u.Length / 2)
-	hdr.Cap = int(u.MaximumLength / 2)
-	return string(utf16.Decode(s))
-}
-
-// SYSTEM_PROCESS_INFORMATION
-type SystemProcessInformation struct {
-	NextEntryOffset              uint32        // ULONG
-	NumberOfThreads              uint32        // ULONG
-	WorkingSetPrivateSize        int64         // LARGE_INTEGER
-	HardFaultCount               uint32        // ULONG
-	NumberOfThreadsHighWatermark uint32        // ULONG
-	CycleTime                    uint64        // ULONGLONG
-	CreateTime                   int64         // LARGE_INTEGER
-	UserTime                     int64         // LARGE_INTEGER
-	KernelTime                   int64         // LARGE_INTEGER
-	ImageName                    unicodeString // UNICODE_STRING
-	BasePriority                 kPriority     // KPRIORITY
-	UniqueProcessId              uintptr       // HANDLE
-	InheritedFromUniqueProcessId uintptr       // HANDLE
-	HandleCount                  uint32        // ULONG
-	SessionId                    uint32        // ULONG
-	UniqueProcessKey             *uint32       // ULONG_PTR
-	PeakVirtualSize              uintptr       // SIZE_T
-	VirtualSize                  uintptr       // SIZE_T
-	PageFaultCount               uint32        // ULONG
-	PeakWorkingSetSize           uintptr       // SIZE_T
-	WorkingSetSize               uintptr       // SIZE_T
-	QuotaPeakPagedPoolUsage      uintptr       // SIZE_T
-	QuotaPagedPoolUsage          uintptr       // SIZE_T
-	QuotaPeakNonPagedPoolUsage   uintptr       // SIZE_T
-	QuotaNonPagedPoolUsage       uintptr       // SIZE_T
-	PagefileUsage                uintptr       // SIZE_T
-	PeakPagefileUsage            uintptr       // SIZE_T
-	PrivatePageCount             uintptr       // SIZE_T
-	ReadOperationCount           int64         // LARGE_INTEGER
-	WriteOperationCount          int64         // LARGE_INTEGER
-	OtherOperationCount          int64         // LARGE_INTEGER
-	ReadTransferCount            int64         // LARGE_INTEGER
-	WriteTransferCount           int64         // LARGE_INTEGER
-	OtherTransferCount           int64         // LARGE_INTEGER
-}
-
-type kWaitReason int32
-
-type clientID struct {
-	UniqueProcess uintptr // HANDLE
-	UniqueThread  uintptr // HANDLE
-}
-
-type systemThreadInformation struct {
-	KernelTime      int64       // LARGE_INTEGER
-	UserTime        int64       // LARGE_INTEGER
-	CreateTime      int64       // LARGE_INTEGER
-	WaitTime        uint32      // ULONG
-	StartAddress    uintptr     // PVOID
-	ClientId        clientID    // CLIENT_ID
-	Priority        kPriority   // KPRIORITY
-	BasePriority    int32       // LONG
-	ContextSwitches uint32      // ULONG
-	ThreadState     uint32      // ULONG
-	WaitReason      kWaitReason // KWAIT_REASON
-}
 
 func add(p unsafe.Pointer, x uintptr) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(p) + x)
 }
 
-func checkProcNtQuerySystemInformationAvailable() error {
+func checkNtDLLProceduresAvailable() error {
 	if ntDLLLoadErr != nil {
 		return errors.Wrap(ntDLLLoadErr, "winapi: can't load dll Ntdll.dll")
 	}
 	if procNtQuerySystemInformationLoadErr != nil {
 		return errors.Wrap(procNtQuerySystemInformationLoadErr, "winapi: can't get procedure NtQuerySystemInformation")
 	}
+	if procNtQueryInformationProcessLoadErr != nil {
+		return errors.Wrap(procNtQueryInformationProcessLoadErr, "winapi: can't get procedure NtQueryInformationProcess")
+	}
+	return nil
+}
+
+func checkKernel32ProceduresAvailable() error {
+	if kernel32DLLErr != nil {
+		return errors.Wrap(kernel32DLLErr, "winapi: can't load dll kernel32.dll")
+	}
+	if procReadProcessMemoryLoadErr != nil {
+		return errors.Wrap(procReadProcessMemoryLoadErr, "winapi: can't get procedure ReadProcessMemory")
+	}
 	return nil
 }
 
 func GetSystemProcessorPerformanceInformation() ([]SystemProcessorPerformanceInformation, error) {
-	if err := checkProcNtQuerySystemInformationAvailable(); err != nil {
+	if err := checkNtDLLProceduresAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -155,7 +70,7 @@ func GetSystemProcessorPerformanceInformation() ([]SystemProcessorPerformanceInf
 	// buffer for results from the windows proc
 	resultBuffer := make([]SystemProcessorPerformanceInformation, maxBuffer)
 	// size of the buffer in memory
-	bufferSize := uintptr(systemProcessorPerformanceInfoSize) * uintptr(maxBuffer)
+	bufferSize := systemProcessorPerformanceInfoSize * uintptr(maxBuffer)
 	// size of the returned response
 	var retSize uint32
 
@@ -171,7 +86,7 @@ func GetSystemProcessorPerformanceInformation() ([]SystemProcessorPerformanceInf
 	}
 
 	// calculate the number of returned elements based on the returned size
-	numReturnedElements := retSize / systemProcessorPerformanceInfoSize
+	numReturnedElements := retSize / uint32(systemProcessorPerformanceInfoSize)
 
 	// trim results to the number of returned elements
 	resultBuffer = resultBuffer[:numReturnedElements]
@@ -179,7 +94,7 @@ func GetSystemProcessorPerformanceInformation() ([]SystemProcessorPerformanceInf
 }
 
 func GetSystemProcessInformation() (map[uint32]*SystemProcessInformation, error) {
-	if err := checkProcNtQuerySystemInformationAvailable(); err != nil {
+	if err := checkNtDLLProceduresAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -202,7 +117,7 @@ func GetSystemProcessInformation() (map[uint32]*SystemProcessInformation, error)
 	const maxProcs = 300
 	const maxThreadsPerProc = 100
 	// technically, windows can have more processes and more threads per process, but we try to calculate average value
-	var currBufferSize = (uintptr(systemProcessInfoSize) + uintptr(systemThreadInfoSize)*uintptr(maxThreadsPerProc)) * uintptr(maxProcs)
+	var currBufferSize = (systemProcessInfoSize + systemThreadInfoSize*uintptr(maxThreadsPerProc)) * uintptr(maxProcs)
 	callWithBufferSize(currBufferSize)
 
 	if retCode != 0 {
@@ -242,4 +157,50 @@ func GetSystemProcessInformation() (map[uint32]*SystemProcessInformation, error)
 	}
 
 	return result, nil
+}
+
+// returns address for ProcessEnvironmentBlock struct
+func GetProcessBasicInformation(processHandle windows.Handle) (*processBasicInformation, error) {
+	if err := checkNtDLLProceduresAvailable(); err != nil {
+		return nil, err
+	}
+
+	var pbi processBasicInformation
+	var retSize int
+	retCode, _, err := procNtQueryInformationProcess.Call(
+		uintptr(processHandle),
+		systemProcessBasicInformationClass,
+		uintptr(unsafe.Pointer(&pbi)),
+		systemProcessBasicInformationSize,
+		uintptr(unsafe.Pointer(&retSize)),
+	)
+
+	if retCode != 0 {
+		return nil, fmt.Errorf("winapi call to NtQueryInformationProcess returned %d. err: %s", retCode, err.Error())
+	}
+
+	return &pbi, nil
+}
+
+func ReadProcessMemory(processHandle windows.Handle, srcAddr uintptr, dstAddr uintptr, size uintptr) (int, error) {
+	var nBytesRead int
+
+	if err := checkKernel32ProceduresAvailable(); err != nil {
+		return nBytesRead, err
+	}
+
+	retCode, _, err := procReadProcessMemory.Call(
+		uintptr(processHandle),
+		srcAddr,
+		dstAddr,
+		size,
+		uintptr(unsafe.Pointer(&nBytesRead)),
+	)
+
+	// ReadProcessMemory function returns 0 in the case of failure
+	if retCode == 0 {
+		return nBytesRead, fmt.Errorf("winapi call to ReadProcessMemory returned %d. err: %s", retCode, err.Error())
+	}
+
+	return nBytesRead, nil
 }

--- a/processes_windows.go
+++ b/processes_windows.go
@@ -3,78 +3,33 @@
 package cagent
 
 import (
-	"context"
-	"errors"
-	"time"
-
-	"github.com/StackExchange/wmi"
-
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/docker"
+	"github.com/cloudradar-monitoring/cagent/pkg/winapi"
+	"github.com/pkg/errors"
 )
 
-const processListTimeout = time.Second * 10
-
-type Win32_Process struct {
-	Name            *string
-	CommandLine     *string
-	ProcessID       *uint32
-	ParentProcessId *uint32
-	ExecutionState  *uint16
-}
-
-func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, connectServerArgs ...interface{}) error {
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- wmi.Query(query, dst, connectServerArgs...)
-	}()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-errChan:
-		return err
-	}
-}
-
 func processes(_ *docker.Watcher) ([]ProcStat, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), processListTimeout)
-	defer cancel()
-
-	wmiProcs := []Win32_Process{}
-
-	err := WMIQueryWithContext(ctx, `SELECT Name, CommandLine, ProcessID, ParentProcessId FROM Win32_Process`, &wmiProcs)
+	procs, err := winapi.GetSystemProcessInformation()
 	if err != nil {
-		if err == context.DeadlineExceeded {
-			return nil, TimeoutError{"WMI query", processListTimeout}
-		}
-		return nil, errors.New("WMI query error: " + err.Error())
+		return nil, errors.Wrap(err, "[PROC] can't get system processes")
 	}
 
-	var procs []ProcStat
-	for _, proc := range wmiProcs {
-		if proc.ProcessID == nil {
+	var result []ProcStat
+	for pid, proc := range procs {
+		if pid == 0 {
 			continue
 		}
 
 		ps := ProcStat{
-			PID:   int(*proc.ProcessID),
-			State: "running",
+			PID:       int(pid),
+			ParentPID: int(proc.InheritedFromUniqueProcessId),
+			State:     "running",
+			Name:      proc.ImageName.String(),
+			Cmdline:   "",
 		}
 
-		if proc.Name != nil {
-			ps.Name = *proc.Name
-		}
-
-		if proc.ParentProcessId != nil {
-			ps.ParentPID = int(*proc.ParentProcessId)
-		}
-
-		if proc.CommandLine != nil {
-			ps.Cmdline = *proc.CommandLine
-		}
-
-		procs = append(procs, ps)
+		result = append(result, ps)
 	}
 
-	return procs, nil
+	return result, nil
 }

--- a/processes_windows.go
+++ b/processes_windows.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/docker"
 	"github.com/cloudradar-monitoring/cagent/pkg/winapi"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 func processes(_ *docker.Watcher) ([]ProcStat, error) {
@@ -15,9 +16,17 @@ func processes(_ *docker.Watcher) ([]ProcStat, error) {
 	}
 
 	var result []ProcStat
+	cmdLineRetrievalFailuresCount := 0
 	for pid, proc := range procs {
 		if pid == 0 {
 			continue
+		}
+
+		cmdLine, err := winapi.GetProcessCommandLine(pid)
+		if err != nil {
+			// there are some edge-cases when we can't get cmdLine in reliable way.
+			// it includes system processes, which are not accessible in user-mode and processes from outside of WOW64 when running as a 32-bit process
+			cmdLineRetrievalFailuresCount++
 		}
 
 		ps := ProcStat{
@@ -25,10 +34,14 @@ func processes(_ *docker.Watcher) ([]ProcStat, error) {
 			ParentPID: int(proc.InheritedFromUniqueProcessId),
 			State:     "running",
 			Name:      proc.ImageName.String(),
-			Cmdline:   "",
+			Cmdline:   cmdLine,
 		}
 
 		result = append(result, ps)
+	}
+
+	if cmdLineRetrievalFailuresCount > 0 {
+		log.Debugf("[PROC] could not get command line for %d processes", cmdLineRetrievalFailuresCount)
 	}
 
 	return result, nil


### PR DESCRIPTION
WMI query is slow and actually does not work when the system is under high load.

1) This PR replaces WMI query with winapi calls, which are:
- list all the processes in system using one winapi call
- for each process tries to get its command line string. (3-4 winapi calls). 
2) Also, some refactorings made to simplify winapi module.

***
Note that in some cases we are unable to get the command line string at all:
- for some system processes, which memory is inaccessible in user mode
- when running 32-bit cagent under WOW64, only 32-bit processes memory is accessible for cagent.
***
Tested on Win10, Windows Server (2012, 2016, 2019)