### PR TITLE
Eliminate WMI call for CPU name retrieval on Windows

### DIFF
--- a/system.go
+++ b/system.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/mem"
 	log "github.com/sirupsen/logrus"
@@ -117,17 +116,14 @@ func (ca *Cagent) HostInfoResults() (MeasurementsMap, error) {
 		case "fqdn":
 			res[field] = getFQDN()
 		case "cpu_model":
-			ctx, cancel := context.WithTimeout(context.Background(), cpuInfoTimeout)
-			defer cancel()
-			cpuInfo, err := cpu.InfoWithContext(ctx)
+			cpuName, err := getProcessorModelName()
 			if err != nil {
 				log.Errorf("[SYSTEM] Failed to read cpu info: %s", err.Error())
 				errs = append(errs, err.Error())
 				res[field] = nil
 				continue
 			}
-
-			res[field] = cpuInfo[0].ModelName
+			res[field] = cpuName
 		case "os_arch":
 			res[field] = runtime.GOARCH
 		case "memory_total_b":

--- a/system_notwindows.go
+++ b/system_notwindows.go
@@ -1,0 +1,26 @@
+// +build !windows
+
+package cagent
+
+import (
+	"context"
+	"errors"
+
+	"github.com/shirou/gopsutil/cpu"
+)
+
+func getProcessorModelName() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cpuInfoTimeout)
+	defer cancel()
+
+	cpuInfos, err := cpu.InfoWithContext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(cpuInfos) == 0 {
+		return "", errors.New("no information about CPU")
+	}
+
+	return cpuInfos[0].ModelName, nil
+}

--- a/system_windows.go
+++ b/system_windows.go
@@ -8,18 +8,18 @@ import (
 )
 
 func getProcessorModelName() (string, error) {
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE)
+	registryKey, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE)
 	if err != nil {
 		return "", err
 	}
 	defer func() {
-		err = k.Close()
+		err = registryKey.Close()
 		if err != nil {
 			log.Warnf("[SYSTEM] could not close registry key handler: %s", err.Error())
 		}
 	}()
 
-	processorName, _, err := k.GetStringValue("ProcessorNameString")
+	processorName, _, err := registryKey.GetStringValue("ProcessorNameString")
 	if err != nil {
 		return "", err
 	}

--- a/system_windows.go
+++ b/system_windows.go
@@ -1,0 +1,28 @@
+// +build windows
+
+package cagent
+
+import (
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows/registry"
+)
+
+func getProcessorModelName() (string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err = k.Close()
+		if err != nil {
+			log.Warnf("[SYSTEM] could not close registry key handler: %s", err.Error())
+		}
+	}()
+
+	processorName, _, err := k.GetStringValue("ProcessorNameString")
+	if err != nil {
+		return "", err
+	}
+
+	return processorName, nil
+}


### PR DESCRIPTION
Now it will use value from registry.