### PR TITLE
Rework hwinfo package error handling

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"errors"
-	"fmt"
 )
 
 // ErrorCollector type allows accumulation of errors in one place
@@ -16,17 +15,6 @@ func (c *ErrorCollector) Add(err error) {
 	if err != nil {
 		c.errs = append(c.errs, err)
 	}
-}
-
-// AddNew creates new error and adds to collection
-func (c *ErrorCollector) AddNew(text string) {
-	c.Add(errors.New(text))
-}
-
-// AddNewf creates new error using specified format and adds to collection
-func (c *ErrorCollector) AddNewf(format string, args ...interface{}) {
-	err := fmt.Errorf(format, args...)
-	c.Add(err)
 }
 
 // HasErrors returns true if there were any errors collected

--- a/pkg/hwinfo/hwinfo.go
+++ b/pkg/hwinfo/hwinfo.go
@@ -31,7 +31,7 @@ type monitorInfo struct {
 func Inventory() (map[string]interface{}, error) {
 	hw, err := fetchInventory()
 	if err != nil {
-		err = errors.Wrap(err, "hwinfo")
+		err = errors.Wrap(err, "[HWINFO]")
 		log.Error(err)
 		return hw, err
 	}

--- a/pkg/hwinfo/system_profiler_test.go
+++ b/pkg/hwinfo/system_profiler_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
 
 func helperLoadSystemProfilerXML(t *testing.T, xmlFileName string) []byte {
@@ -23,9 +21,8 @@ func helperLoadSystemProfilerXML(t *testing.T, xmlFileName string) []byte {
 func TestParseOutputToListOfPCIDevices(t *testing.T) {
 	xml := helperLoadSystemProfilerXML(t, "pci.xml")
 
-	errs := &common.ErrorCollector{}
-	pciDevicesList := parseOutputToListOfPCIDevices(bytes.NewReader(xml), errs)
-	assert.False(t, errs.HasErrors())
+	pciDevicesList, err := parseOutputToListOfPCIDevices(bytes.NewReader(xml))
+	assert.NoError(t, err)
 
 	expectedPCIDevicesList := []*pciDeviceInfo{
 		{
@@ -71,9 +68,8 @@ func TestParseOutputToListOfPCIDevices(t *testing.T) {
 func TestParseOutputToListOfUSBDevices(t *testing.T) {
 	xml := helperLoadSystemProfilerXML(t, "usb.xml")
 
-	errs := &common.ErrorCollector{}
-	usbDevicesList := parseOutputToListOfUSBDevices(bytes.NewReader(xml), errs)
-	assert.False(t, errs.HasErrors())
+	usbDevicesList, err := parseOutputToListOfUSBDevices(bytes.NewReader(xml))
+	assert.NoError(t, err)
 
 	expectedUSBDevicesList := []*usbDeviceInfo{
 		{
@@ -138,9 +134,8 @@ func TestParseOutputToListOfUSBDevices(t *testing.T) {
 func TestParseOutputToListOfDisplays(t *testing.T) {
 	xml := helperLoadSystemProfilerXML(t, "displays.xml")
 
-	errs := &common.ErrorCollector{}
-	displayList := parseOutputToListOfDisplays(bytes.NewReader(xml), errs)
-	assert.False(t, errs.HasErrors())
+	displayList, err := parseOutputToListOfDisplays(bytes.NewReader(xml))
+	assert.NoError(t, err)
 
 	expectedDisplayList := []*monitorInfo{
 		{


### PR DESCRIPTION
There was a problem of mixing real errors and minor info messages together.
This PR changes all work with errors to be consistent with the rest part of cagent.