### PR TITLE
Fix RPM package upgrade routine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 cmd/cagent/cagent
 .DS_Store
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,6 +90,11 @@ nfpm:
     postinstall: "pkg-scripts/postinstall.sh"
     preremove: "pkg-scripts/preremove.sh"
 
+  overrides:
+    rpm:
+      scripts:
+        preremove: "pkg-scripts/preremove-rpm.sh"
+
 release:
   github:
     owner: cloudradar-monitoring

--- a/pkg-scripts/postinstall.sh
+++ b/pkg-scripts/postinstall.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-/usr/bin/cagent -s cagent -c /etc/cagent/cagent.conf
+/usr/bin/cagent -y -s cagent -c /etc/cagent/cagent.conf
 /usr/bin/cagent -t || true

--- a/pkg-scripts/preremove-rpm.sh
+++ b/pkg-scripts/preremove-rpm.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# rpm executes this script with the number of previous known versions. It allows us to determine if we upgrading or installing first time:
+# Removing during upgrade:         1 or higher
+# Remove last version of package:  0
+prevVersionsCount=$1
+
+# we need to uninstall service only if we are removing the last packages
+if [[ ${prevVersionsCount} -lt 1 ]] ; then
+  /usr/bin/cagent -u || true
+fi


### PR DESCRIPTION
- Added -y option (automatic yes to prompts). This option should be used when no interaction with user is required (e.g. during package installation)
- special version of preremove script is added for RPM packaging. It can distinguish between upgrade and casual uninstall routine.
- 'dist' folder added to .gitignore
- fixed console output when asking confirmation.