### PR TITLE
Monitor memory and CPU used by each process

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -225,7 +225,15 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 
 	measurements = measurements.AddWithPrefix("net.", netResults)
 
-	proc, processList, err := ca.ProcessesResult()
+	mem, memStat, err := ca.MemResults()
+	if err != nil {
+		// no need to log because already done inside MemResults()
+		errs = append(errs, err.Error())
+	}
+
+	measurements = measurements.AddWithPrefix("mem.", mem)
+
+	proc, processList, err := ca.ProcessesResult(memStat)
 	if err != nil {
 		// no need to log because already done inside ProcessesResult()
 		errs = append(errs, err.Error())
@@ -240,14 +248,6 @@ func (ca *Cagent) GetAllMeasurements() (MeasurementsMap, error) {
 	}
 
 	measurements = measurements.AddWithPrefix("listeningports.", ports)
-
-	mem, err := ca.MemResults()
-	if err != nil {
-		// no need to log because already done inside MemResults()
-		errs = append(errs, err.Error())
-	}
-
-	measurements = measurements.AddWithPrefix("mem.", mem)
 
 	swap, err := ca.SwapResults()
 	if err != nil {

--- a/mem.go
+++ b/mem.go
@@ -5,8 +5,8 @@ package cagent
 import (
 	"context"
 	"errors"
-	"time"
 	"runtime"
+	"time"
 
 	"github.com/shirou/gopsutil/mem"
 	log "github.com/sirupsen/logrus"
@@ -14,7 +14,7 @@ import (
 
 const memGetTimeout = time.Second * 10
 
-func (ca *Cagent) MemResults() (MeasurementsMap, error) {
+func (ca *Cagent) MemResults() (MeasurementsMap, *mem.VirtualMemoryStat, error) {
 	results := MeasurementsMap{}
 	ctx, cancel := context.WithTimeout(context.Background(), memGetTimeout)
 	defer cancel()
@@ -38,7 +38,7 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 	memStat, err := mem.VirtualMemoryWithContext(ctx)
 	if err != nil {
 		log.Errorf("[MEM] Failed to get virtual memory stat: %s", err.Error())
-		return results, errors.New("MEM: " + err.Error())
+		return results, memStat, errors.New("MEM: " + err.Error())
 	}
 
 	results["total_B"] = memStat.Total
@@ -69,5 +69,5 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 		results["available_percent"] = floatToIntPercentRoundUP(float64(results["available_B"].(int)) / float64(memStat.Total))
 	}
 
-	return results, nil
+	return results, memStat, nil
 }

--- a/mem_windows.go
+++ b/mem_windows.go
@@ -16,7 +16,7 @@ import (
 
 const memGetTimeout = time.Second * 10
 
-func (ca *Cagent) MemResults() (MeasurementsMap, error) {
+func (ca *Cagent) MemResults() (MeasurementsMap, *mem.VirtualMemoryStat, error) {
 	results := MeasurementsMap{}
 
 	var errs []string
@@ -73,8 +73,8 @@ func (ca *Cagent) MemResults() (MeasurementsMap, error) {
 	results["cached_percent"] = floatToIntPercentRoundUP(float64(cachedBytes) / float64(memStat.Total))
 
 	if len(errs) == 0 {
-		return results, nil
+		return results, memStat, nil
 	}
 
-	return results, errors.New("MEM: " + strings.Join(errs, "; "))
+	return results, memStat, errors.New("MEM: " + strings.Join(errs, "; "))
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,8 +1,14 @@
 package common
 
+import "math"
+
 func MergeStringMaps(mapA, mapB map[string]interface{}) map[string]interface{} {
 	for k, v := range mapB {
 		mapA[k] = v
 	}
 	return mapA
+}
+
+func RoundToTwoDecimalPlaces(v float64) float64 {
+	return math.Round(v*100) / 100
 }

--- a/pkg/winapi/facade.go
+++ b/pkg/winapi/facade.go
@@ -116,3 +116,14 @@ func GetIsServiceHaveDelayedAutoStartFlag(serviceHandle windows.Handle) (bool, e
 	infoStructure := (*serviceDelayedAutoStartInfo)(unsafe.Pointer(&resultBuffer[0]))
 	return infoStructure.DelayedAutoStart, nil
 }
+
+func CalculateProcessCPUUsagePercent(p1, p2 *SystemProcessInformation, delta float64, cpuCount uint8) float64 {
+	if delta == 0 {
+		return 0
+	}
+	delta = delta * float64(cpuCount)
+
+	deltaProc := float64((p2.UserTime+p2.KernelTime)-(p1.UserTime+p1.KernelTime)) * HundredNSToTick
+	overallPercent := (deltaProc / delta) * 100
+	return overallPercent
+}


### PR DESCRIPTION
New fields added for each process:
```
cpu_avg_usage_percent
rss // Resident Set Size or Private Working Set Size (actual memory size used by process)
vms // Virtual Memory Size (for some systems like Windows it's very big by default, even if process does not use it)
memory_usage_percent
```

The cpu_avg_usage_percent calculated since last check, therefore it's available only after second check.