### PR TITLE
Do not fail if there was any stderr output from ghw/pci library

### DIFF
--- a/pkg/hwinfo/hwinfo_other.go
+++ b/pkg/hwinfo/hwinfo_other.go
@@ -71,7 +71,8 @@ func listPCIDevices() ([]*pciDeviceInfo, error) {
 		return nil, errors.Wrap(ghwErr, "there were error while retrieving PCI information using ghw")
 	}
 	if len(stderrOutput) > 0 {
-		return nil, errors.Errorf("there were error output while retrieving PCI information using ghw: %s", stderrOutput)
+		// ghw only reports to stderr in case if system files are missing or there was failure while reading it
+		log.Infof("system is not supported: %s", stderrOutput)
 	}
 
 	result := make([]*pciDeviceInfo, 0, len(devices))

--- a/pkg/hwinfo/hwinfo_other.go
+++ b/pkg/hwinfo/hwinfo_other.go
@@ -72,7 +72,7 @@ func listPCIDevices() ([]*pciDeviceInfo, error) {
 	}
 	if len(stderrOutput) > 0 {
 		// ghw only reports to stderr in case if system files are missing or there was failure while reading it
-		log.Infof("system is not supported: %s", stderrOutput)
+		log.Warnf("[HWINFO] got error output while retrieving PCI information using ghw: %s\nProbably the system is not supported or system files unreadable.", stderrOutput)
 	}
 
 	result := make([]*pciDeviceInfo, 0, len(devices))


### PR DESCRIPTION
If some system file is missing, it's not an error. We will report it as 'info' message