### PR TITLE
Fix potential panic when listing upstart services

### DIFF
--- a/pkg/monitoring/services/services_nonwindows.go
+++ b/pkg/monitoring/services/services_nonwindows.go
@@ -265,6 +265,11 @@ func ListUpstartServices() ([]SysVService, error) {
 
 		stateParts := strings.Split(strings.TrimSuffix(parts[1], ","), "/")
 
+		if len(stateParts) < 2 {
+			log.WithField("line", strings.Join(parts, " ")).Debug("Parsing services line failed")
+			continue
+		}
+
 		services = append(services,
 			SysVService{UnitFile: parts[0], State: stateParts[1]},
 		)


### PR DESCRIPTION
While testing on the Synology devices I experienced a panic on startup.

The earlier check:
```go
if strings.HasPrefix(parts[0], "network-interface") {
	continue
}
```
is not enough because other, unexpected, values can appear.

I added a more generic check and in case of an unexpected outcome the value is logged and the entry ignored.