### PR TITLE
fix: run dmidecode without sudo on Darwin

### DIFF
--- a/pkg/hwinfo/hwinfo_darwin.go
+++ b/pkg/hwinfo/hwinfo_darwin.go
@@ -11,6 +11,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func dmidecodeCommand() string {
+	return "dmidecode"
+}
+
 func runSystemProfiler(dataType string) ([]byte, error) {
 	cmd := exec.Command("system_profiler", "-xml", dataType)
 	buf := bytes.Buffer{}

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/cloudradar-monitoring/dmidecode"
@@ -63,9 +64,18 @@ func retrieveInfoUsingDmiDecode() (map[string]interface{}, error) {
 		return nil, nil
 	}
 
-	// expecting 'sudo' package is installed and /etc/sudoers.d/cagent-dmidecode is present
-	const dmidecodeCmd = "sudo dmidecode"
-	cmd := exec.Command("/bin/sh", "-c", dmidecodeCmd)
+	var dmidecodeCmd []string
+
+	// run dmidecode as command argument to shell
+	dmidecodeCmd = append(dmidecodeCmd, "-c")
+
+	if runtime.GOOS != "darwin" {
+		// expecting 'sudo' package is installed and /etc/sudoers.d/cagent-dmidecode is present
+		dmidecodeCmd = append(dmidecodeCmd, "sudo")
+	}
+	dmidecodeCmd = append(dmidecodeCmd, "dmidecode")
+
+	cmd := exec.Command("/bin/sh", dmidecodeCmd...)
 
 	stdoutBuffer := bytes.Buffer{}
 	cmd.Stdout = bufio.NewWriter(&stdoutBuffer)

--- a/pkg/hwinfo/hwinfo_other.go
+++ b/pkg/hwinfo/hwinfo_other.go
@@ -22,6 +22,11 @@ import (
 
 var lsusbLineRegexp = regexp.MustCompile(`[0-9|a-z|A-Z|.|/|-|:|\[|\]|_|+| ]+`)
 
+func dmidecodeCommand() string {
+	// expecting 'sudo' package is installed and /etc/sudoers.d/cagent-dmidecode is present
+	return "sudo dmidecode"
+}
+
 func captureStderr(funcToExecute func()) (string, error) {
 	r, w, err := os.Pipe()
 	if err != nil {


### PR DESCRIPTION
on MacOS it provides result without being called as sudo
Call with sudo prompts for password and it fails due to
absence of `cagent-dmidecode` for MacOS package