### PR TITLE
fix: use common.MeasurementsMap for vmstat results

### DIFF
--- a/pkg/monitoring/vmstat/hyperv/hyperv_wmi.go
+++ b/pkg/monitoring/vmstat/hyperv/hyperv_wmi.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/StackExchange/wmi"
 	"github.com/sirupsen/logrus"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
 
 var guestNetworkRegexp *regexp.Regexp
@@ -78,8 +80,8 @@ type hypervStat struct {
 
 var hypervPath = "\\Hyper-V Hypervisor Virtual processor(*)\\CPU Wait Time Per Dispatch"
 
-func (im *impl) GetMeasurements() (map[string]interface{}, error) {
-	meas := make(map[string]interface{})
+func (im *impl) GetMeasurements() (common.MeasurementsMap, error) {
+	meas := make(common.MeasurementsMap)
 
 	stat := &hypervStat{
 		List: make(map[string]vmStat),

--- a/pkg/monitoring/vmstat/types/types.go
+++ b/pkg/monitoring/vmstat/types/types.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"errors"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
 
 var (
@@ -17,5 +19,5 @@ type Provider interface {
 
 	Name() string
 	IsAvailable() error
-	GetMeasurements() (map[string]interface{}, error)
+	GetMeasurements() (common.MeasurementsMap, error)
 }


### PR DESCRIPTION
Update `GetMeasurements` for vmstat package due to merge of #136 