### PR TITLE
fix: detect CPU count on *nix and darwin

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,6 +1,60 @@
 package common
 
-import "math"
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var (
+	Timeout    = 3 * time.Second
+	ErrTimeout = errors.New("invoker: command timed out")
+)
+
+type Invoker interface {
+	CommandWithContext(context.Context, string, ...string) ([]byte, error)
+}
+
+type Invoke struct{}
+
+var _ Invoker = (*Invoke)(nil)
+
+func (i Invoke) CommandWithContext(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, arg...)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		return buf.Bytes(), err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return buf.Bytes(), err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// RunCommandWithContext convenience wrapper to CommandWithContext
+func RunCommandWithContext(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	var invoke Invoke
+
+	return invoke.CommandWithContext(ctx, name, arg...)
+}
+
+// RunCommandInBackground convenience wrapper to RunCommandWithContext
+func RunCommandInBackground(name string, arg ...string) ([]byte, error) {
+	return RunCommandWithContext(context.Background(), name, arg...)
+}
 
 func MergeStringMaps(mapA, mapB map[string]interface{}) map[string]interface{} {
 	for k, v := range mapB {
@@ -11,4 +65,61 @@ func MergeStringMaps(mapA, mapB map[string]interface{}) map[string]interface{} {
 
 func RoundToTwoDecimalPlaces(v float64) float64 {
 	return math.Round(v*100) / 100
+}
+
+// GetEnv retrieves the environment variable key. If it does not exist it returns the default.
+func GetEnv(key string, dfault string, combineWith ...string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		value = dfault
+	}
+
+	switch len(combineWith) {
+	case 0:
+		return value
+	case 1:
+		return filepath.Join(value, combineWith[0])
+	default:
+		all := make([]string, len(combineWith)+1)
+		all[0] = value
+		copy(all[1:], combineWith)
+		return filepath.Join(all...)
+	}
+}
+
+// ReadLines reads contents from a file and splits them by new lines.
+// A convenience wrapper to ReadLinesOffsetN(filename, 0, -1).
+// from github.com/shriou/gopsutil/internal/common.go
+func ReadLines(filename string) ([]string, error) {
+	return ReadLinesOffsetN(filename, 0, -1)
+}
+
+// ReadLines reads contents from file and splits them by new line.
+// from github.com/shriou/gopsutil/internal/common.go
+// The offset tells at which line number to start.
+// The count determines the number of lines to read (starting from offset):
+//   n >= 0: at most n lines
+//   n < 0: whole file
+func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return []string{""}, err
+	}
+	defer f.Close()
+
+	var ret []string
+
+	r := bufio.NewReader(f)
+	for i := 0; i < n+int(offset) || n < 0; i++ {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if i < int(offset) {
+			continue
+		}
+		ret = append(ret, strings.Trim(line, "\n"))
+	}
+
+	return ret, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -18,6 +18,7 @@ var (
 	ErrTimeout = errors.New("invoker: command timed out")
 )
 
+// Invoker executes command in context and gathers stdout/stderr output into slice
 type Invoker interface {
 	CommandWithContext(context.Context, string, ...string) ([]byte, error)
 }

--- a/pkg/hwinfo/hwinfo_darwin.go
+++ b/pkg/hwinfo/hwinfo_darwin.go
@@ -15,6 +15,15 @@ import (
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
 
+type cpuInfo struct {
+	manufacturer      string
+	manufacturingInfo string
+	description       string
+	coreCount         string
+	coreEnabled       string
+	threadCount       string
+}
+
 func dmidecodeCommand() string {
 	return "dmidecode"
 }

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -17,15 +17,6 @@ import (
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
 
-// type cpuInfo struct {
-// 	manufacturer      string
-// 	manufacturingInfo string
-// 	description       string
-// 	coreCount         string
-// 	coreEnabled       string
-// 	threadCount       string
-// }
-
 func isCommandAvailable(name string) bool {
 	cmd := exec.Command("/bin/sh", "-c", "command", "-v", name)
 	if err := cmd.Run(); err != nil {

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -17,14 +17,14 @@ import (
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
 
-type cpuInfo struct {
-	manufacturer      string
-	manufacturingInfo string
-	description       string
-	coreCount         string
-	coreEnabled       string
-	threadCount       string
-}
+// type cpuInfo struct {
+// 	manufacturer      string
+// 	manufacturingInfo string
+// 	description       string
+// 	coreCount         string
+// 	coreEnabled       string
+// 	threadCount       string
+// }
 
 func isCommandAvailable(name string) bool {
 	cmd := exec.Command("/bin/sh", "-c", "command", "-v", name)

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -60,17 +60,6 @@ func fetchInventory() (map[string]interface{}, error) {
 	cpus, err := listCPUs()
 	errorCollector.Add(err)
 	if cpus != nil {
-		// encodedCpus := make(map[string]interface{})
-
-		// for i := range cpus {
-		// 	encodedCpus[fmt.Sprintf("cpu.%d.manufacturer", i)] = cpus[i].manufacturer
-		// 	encodedCpus[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = cpus[i].manufacturingInfo
-		// 	encodedCpus[fmt.Sprintf("cpu.%d.description", i)] = cpus[i].description
-		// 	encodedCpus[fmt.Sprintf("cpu.%d.core_count", i)] = cpus[i].coreCount
-		// 	encodedCpus[fmt.Sprintf("cpu.%d.core_enabled", i)] = cpus[i].coreEnabled
-		// 	encodedCpus[fmt.Sprintf("cpu.%d.thread_count", i)] = cpus[i].threadCount
-		// }
-
 		res = common.MergeStringMaps(res, cpus)
 	}
 
@@ -146,19 +135,4 @@ func retrieveInfoUsingDmiDecode() (map[string]interface{}, error) {
 	}
 
 	return res, nil
-}
-
-func encodeCPUs(cpus []cpuInfo) map[string]interface{} {
-	encodedCpus := make(map[string]interface{})
-
-	for i := range cpus {
-		encodedCpus[fmt.Sprintf("cpu.%d.manufacturer", i)] = cpus[i].manufacturer
-		encodedCpus[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = cpus[i].manufacturingInfo
-		encodedCpus[fmt.Sprintf("cpu.%d.description", i)] = cpus[i].description
-		encodedCpus[fmt.Sprintf("cpu.%d.core_count", i)] = cpus[i].coreCount
-		encodedCpus[fmt.Sprintf("cpu.%d.core_enabled", i)] = cpus[i].coreEnabled
-		encodedCpus[fmt.Sprintf("cpu.%d.thread_count", i)] = cpus[i].threadCount
-	}
-
-	return encodedCpus
 }

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -5,10 +5,12 @@ package hwinfo
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/cloudradar-monitoring/dmidecode"
 	"github.com/pkg/errors"
@@ -16,6 +18,57 @@ import (
 
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
+
+type cpuInfo struct {
+	manufacturer      string
+	manufacturingInfo string
+	description       string
+	coreCount         string
+	coreEnabled       string
+	threadCount       string
+}
+
+var (
+	Timeout    = 3 * time.Second
+	ErrTimeout = errors.New("invoker: command timed out")
+)
+
+type Invoker interface {
+	Command(string, ...string) ([]byte, error)
+	CommandWithContext(context.Context, string, ...string) ([]byte, error)
+}
+
+type Invoke struct{}
+
+func (i Invoke) Command(name string, arg ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+	return i.CommandWithContext(ctx, name, arg...)
+}
+
+func (i Invoke) CommandWithContext(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, arg...)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		return buf.Bytes(), err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return buf.Bytes(), err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func RunCommandWithContext(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	var invoke Invoke
+
+	return invoke.CommandWithContext(ctx, name, arg...)
+}
 
 func isCommandAvailable(name string) bool {
 	cmd := exec.Command("/bin/sh", "-c", "command", "-v", name)
@@ -46,6 +99,23 @@ func fetchInventory() (map[string]interface{}, error) {
 	errorCollector.Add(err)
 	if len(displays) > 0 {
 		res["displays.list"] = displays
+	}
+
+	cpus, err := listCPUs()
+	errorCollector.Add(err)
+	if len(cpus) > 0 {
+		encodedCpus := make(map[string]interface{})
+
+		for i := range cpus {
+			encodedCpus[fmt.Sprintf("cpu.%d.manufacturer", i)] = cpus[i].manufacturer
+			encodedCpus[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = cpus[i].manufacturingInfo
+			encodedCpus[fmt.Sprintf("cpu.%d.description", i)] = cpus[i].description
+			encodedCpus[fmt.Sprintf("cpu.%d.core_count", i)] = cpus[i].coreCount
+			encodedCpus[fmt.Sprintf("cpu.%d.core_enabled", i)] = cpus[i].coreEnabled
+			encodedCpus[fmt.Sprintf("cpu.%d.thread_count", i)] = cpus[i].threadCount
+		}
+
+		res = common.MergeStringMaps(res, encodedCpus)
 	}
 
 	dmiDecodeResults, err := retrieveInfoUsingDmiDecode()
@@ -117,20 +187,6 @@ func retrieveInfoUsingDmiDecode() (map[string]interface{}, error) {
 		}
 	} else if err != dmidecode.ErrNotFound {
 		log.WithError(err).Info("[HWINFO] failed fetching memory device info")
-	}
-
-	var reqCPU []dmidecode.ReqProcessor
-	if err = dmi.Get(&reqCPU); err == nil {
-		for i := range reqCPU {
-			res[fmt.Sprintf("cpu.%d.manufacturer", i)] = reqCPU[i].Manufacturer
-			res[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = reqCPU[i].Signature.String()
-			res[fmt.Sprintf("cpu.%d.description", i)] = reqCPU[i].Version
-			res[fmt.Sprintf("cpu.%d.core_count", i)] = reqCPU[i].CoreCount
-			res[fmt.Sprintf("cpu.%d.core_enabled", i)] = reqCPU[i].CoreEnabled
-			res[fmt.Sprintf("cpu.%d.thread_count", i)] = reqCPU[i].ThreadCount
-		}
-	} else if err != dmidecode.ErrNotFound {
-		log.WithError(err).Info("[HWINFO] failed fetching cpu info")
 	}
 
 	return res, nil

--- a/pkg/hwinfo/hwinfo_other.go
+++ b/pkg/hwinfo/hwinfo_other.go
@@ -8,10 +8,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/jaypipes/ghw"
@@ -21,6 +22,23 @@ import (
 )
 
 var lsusbLineRegexp = regexp.MustCompile(`[0-9|a-z|A-Z|.|/|-|:|\[|\]|_|+| ]+`)
+
+type cpuStat struct {
+	CPU        int32    `json:"cpu"`
+	VendorID   string   `json:"vendorId"`
+	Family     string   `json:"family"`
+	Model      string   `json:"model"`
+	Stepping   int32    `json:"stepping"`
+	PhysicalID string   `json:"physicalId"`
+	CoreID     string   `json:"coreId"`
+	Cores      int32    `json:"cores"`
+	ModelName  string   `json:"modelName"`
+	Mhz        float64  `json:"mhz"`
+	CacheSize  int32    `json:"cacheSize"`
+	Flags      []string `json:"flags"`
+	Microcode  string   `json:"microcode"`
+	Siblings   int32    `json:"siblings"`
+}
 
 func dmidecodeCommand() string {
 	// expecting 'sudo' package is installed and /etc/sudoers.d/cagent-dmidecode is present
@@ -193,4 +211,235 @@ func listDisplays() ([]*monitorInfo, error) {
 	}
 
 	return results, nil
+}
+
+// this part is extended version of github.com/shirou/gopsutil/cpu/cpu_linux.go
+// it need own implementation as gopsutil does return amount of threads not CPUs
+// and ignores siblings field which is indicating amount of threads
+// /proc/cpuinfo is parsed in following manner
+//   - physical id: actual CPU installed in the socket
+//   - cores:       physical cores per CPU in the socket
+//   - siblings:    amount of threads per CPU in the socket
+// e.g. on HT CPU with 2 cores amount of siblings will be 4
+func listCPUs() ([]cpuInfo, error) {
+	lines, _ := readLines(getEnv("HOST_PROC", "/proc", "cpuinfo"))
+
+	var cpus []cpuStat
+	var processorName string
+
+	c := cpuStat{CPU: -1, Cores: 1}
+	for _, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSpace(fields[0])
+		value := strings.TrimSpace(fields[1])
+
+		switch key {
+		case "Processor":
+			processorName = value
+		case "processor":
+			if c.CPU >= 0 {
+				err := finishCPUInfo(&c)
+				if err != nil {
+					return nil, err
+				}
+				cpus = append(cpus, c)
+			}
+			c = cpuStat{Cores: 1, ModelName: processorName}
+			t, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			c.CPU = int32(t)
+		case "vendorId", "vendor_id":
+			c.VendorID = value
+		case "cpu family":
+			c.Family = value
+		case "model":
+			c.Model = value
+		case "model name", "cpu":
+			c.ModelName = value
+			if strings.Contains(value, "POWER8") ||
+				strings.Contains(value, "POWER7") {
+				c.Model = strings.Split(value, " ")[0]
+				c.Family = "POWER"
+				c.VendorID = "IBM"
+			}
+		case "stepping", "revision":
+			val := value
+
+			if key == "revision" {
+				val = strings.Split(value, ".")[0]
+			}
+
+			t, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			c.Stepping = int32(t)
+		case "cpu MHz", "clock":
+			// treat this as the fallback value, thus we ignore error
+			if t, err := strconv.ParseFloat(strings.Replace(value, "MHz", "", 1), 64); err == nil {
+				c.Mhz = t
+			}
+		case "cache size":
+			t, err := strconv.ParseInt(strings.Replace(value, " KB", "", 1), 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			c.CacheSize = int32(t)
+		case "physical id":
+			c.PhysicalID = value
+		case "core id":
+			c.CoreID = value
+		case "flags", "Features":
+			c.Flags = strings.FieldsFunc(value, func(r rune) bool {
+				return r == ',' || r == ' '
+			})
+		case "cpu cores":
+			val := value
+
+			t, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+
+			c.Cores = int32(t)
+		case "microcode":
+			c.Microcode = value
+		case "siblings":
+			val := value
+
+			t, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+
+			c.Siblings = int32(t)
+		}
+	}
+
+	if c.CPU >= 0 {
+		err := finishCPUInfo(&c)
+		if err != nil {
+			return nil, err
+		}
+		cpus = append(cpus, c)
+	}
+
+	sorted := make(map[string]*cpuInfo)
+
+	for _, cpu := range cpus {
+		if _, found := sorted[cpu.PhysicalID]; !found {
+			info := &cpuInfo{
+				manufacturer:      cpu.VendorID,
+				manufacturingInfo: fmt.Sprintf("Model %s Family %s Stepping %d", cpu.Model, cpu.Family, cpu.Stepping),
+				description:       cpu.ModelName,
+				coreCount:         fmt.Sprintf("%d", cpu.Cores),
+				coreEnabled:       fmt.Sprintf("%d", cpu.Cores),
+				threadCount:       fmt.Sprintf("%d", cpu.Siblings),
+			}
+
+			sorted[cpu.PhysicalID] = info
+		}
+	}
+
+	var cInfo []cpuInfo
+	for _, cpu := range sorted {
+		cInfo = append(cInfo, *cpu)
+	}
+
+	return cInfo, nil
+}
+
+func finishCPUInfo(c *cpuStat) error {
+	var lines []string
+	var err error
+	var value float64
+
+	if len(c.CoreID) == 0 {
+		lines, err = readLines(sysCPUPath(c.CPU, "topology/core_id"))
+		if err == nil {
+			c.CoreID = lines[0]
+		}
+	}
+
+	// override the value of c.Mhz with cpufreq/cpuinfo_max_freq regardless
+	// of the value from /proc/cpuinfo because we want to report the maximum
+	// clock-speed of the CPU for c.Mhz, matching the behaviour of Windows
+	lines, err = readLines(sysCPUPath(c.CPU, "cpufreq/cpuinfo_max_freq"))
+	// if we encounter errors below such as there are no cpuinfo_max_freq file,
+	// we just ignore. so let Mhz is 0.
+	if err != nil {
+		return nil
+	}
+	value, err = strconv.ParseFloat(lines[0], 64)
+	if err != nil {
+		return nil
+	}
+	c.Mhz = value / 1000.0 // value is in kHz
+	if c.Mhz > 9999 {
+		c.Mhz = c.Mhz / 1000.0 // value in Hz
+	}
+	return nil
+}
+
+// ReadLines reads contents from a file and splits them by new lines.
+// A convenience wrapper to ReadLinesOffsetN(filename, 0, -1).
+func readLines(filename string) ([]string, error) {
+	return readLinesOffsetN(filename, 0, -1)
+}
+
+// ReadLines reads contents from file and splits them by new line.
+// The offset tells at which line number to start.
+// The count determines the number of lines to read (starting from offset):
+//   n >= 0: at most n lines
+//   n < 0: whole file
+func readLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return []string{""}, err
+	}
+	defer f.Close()
+
+	var ret []string
+
+	r := bufio.NewReader(f)
+	for i := 0; i < n+int(offset) || n < 0; i++ {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if i < int(offset) {
+			continue
+		}
+		ret = append(ret, strings.Trim(line, "\n"))
+	}
+
+	return ret, nil
+}
+
+func sysCPUPath(cpu int32, relPath string) string {
+	return getEnv("HOST_SYS", "/sys", fmt.Sprintf("devices/system/cpu/cpu%d", cpu), relPath)
+}
+
+func getEnv(key string, dfault string, combineWith ...string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		value = dfault
+	}
+
+	switch len(combineWith) {
+	case 0:
+		return value
+	case 1:
+		return filepath.Join(value, combineWith[0])
+	default:
+		all := make([]string, len(combineWith)+1)
+		all[0] = value
+		copy(all[1:], combineWith)
+		return filepath.Join(all...)
+	}
 }


### PR DESCRIPTION
On *nix and darwin use `/proc/cpuinfo` and `sysctl` respectively to detect CPU information.
Fixes issue when OS is running on `VmWare` and `dmidecode` reports amount of sockets provided by hypervisor.