### PR TITLE
fix: remove dependency to smartmontools

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,6 @@ nfpm:
   - dmidecode
   - usbutils
   - sudo
-  - smartmontools
 
   # Recommend to install root SSL certificates
   recommends:


### PR DESCRIPTION
`smartmontools` in most linux distributions is of version `6.5` comparing to required by cagent `7.0`