### PR TITLE
Fix warnings reported by go vet and golangci-lint

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -558,7 +558,10 @@ func rerunDetached() error {
 		"PID": cmd.Process.Pid,
 	}).Infoln("Cagent will continue in background...")
 
-	cmd.Process.Release()
+	err = cmd.Process.Release()
+	if err != nil {
+		log.WithError(err).Warn("wasn't able to release process resources")
+	}
 	return nil
 }
 

--- a/log.go
+++ b/log.go
@@ -71,10 +71,15 @@ func addLogFileHook(file string, flag int, chmod os.FileMode) error {
 // Fire event
 func (hook *logrusFileHook) Fire(entry *logrus.Entry) error {
 	plainformat, err := hook.formatter.Format(entry)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "unable to format log entry %v, %v", entry, err)
+		return err
+	}
+
 	line := string(plainformat)
 	_, err = hook.file.WriteString(line)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to write file on filehook(entry.String)%v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "unable to write file on filehook(entry.String) %v", err)
 		return err
 	}
 

--- a/network.go
+++ b/network.go
@@ -149,7 +149,9 @@ func (nw *NetWatcher) fillEmptyMeasurements(results common.MeasurementsMap, inte
 
 // fillCountersMeasurements used to fill measurements with nil's for all non-excluded interfaces
 func (nw *NetWatcher) fillCountersMeasurements(results common.MeasurementsMap, interfaces []utilnet.InterfaceStat, excludedInterfacesByName map[string]struct{}) error {
-	ctx, _ := context.WithTimeout(context.Background(), netGetCountersTimeout)
+	ctx, cancelFn := context.WithTimeout(context.Background(), netGetCountersTimeout)
+	defer cancelFn()
+
 	counters, err := utilnet.IOCountersWithContext(ctx, true)
 	if err != nil {
 		// fill empty measurements for not-excluded interfaces

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -10,7 +10,7 @@ type ErrorCollector struct {
 	errs []error
 }
 
-// Add adds error to collection
+// Add adds error to collection if err is not nil
 func (c *ErrorCollector) Add(err error) {
 	if err != nil {
 		c.errs = append(c.errs, err)

--- a/raid.go
+++ b/raid.go
@@ -22,7 +22,7 @@ type Raid struct {
 	Active  []int
 }
 
-var failed = regexp.MustCompile("\\[([U_]+)\\]")
+var failed = regexp.MustCompile(`\[([U_]+)\]`)
 
 func (r Raid) GetFailedAndMissingPhysicalDevices() (failedDevices []string, missingDevicesCount int) {
 	for _, deviceIndex := range r.Failed {
@@ -45,7 +45,7 @@ func (r Raid) GetActivePhysicalDevices() []string {
 	return activeDevices
 }
 
-func parseMdstat(data string) (RaidArrays, error) {
+func parseMdstat(data string) RaidArrays {
 	raids := []Raid{}
 	lines := strings.Split(data, "\n")
 
@@ -88,7 +88,7 @@ func parseMdstat(data string) (RaidArrays, error) {
 
 		raids = append(raids, raid)
 	}
-	return raids, nil
+	return raids
 }
 
 func (ar RaidArrays) Measurements() common.MeasurementsMap {
@@ -132,11 +132,6 @@ func (ca *Cagent) RaidState() (common.MeasurementsMap, error) {
 		return nil, err
 	}
 
-	raidArrays, err := parseMdstat(string(buf))
-
-	if err != nil {
-		return common.MeasurementsMap{}, err
-	}
-
+	raidArrays := parseMdstat(string(buf))
 	return raidArrays.Measurements(), nil
 }

--- a/raid_test.go
+++ b/raid_test.go
@@ -124,11 +124,7 @@ unused devices: <none>`, common.MeasurementsMap{
 			"md1.type":                      "raid1"}, false}}
 
 	for _, tt := range tests {
-		got, err := parseMdstat(tt.data)
-		if (err != nil) != tt.wantErr {
-			t.Errorf("%q. parseMdstat() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-			continue
-		}
+		got := parseMdstat(tt.data)
 		measurements := got.Measurements()
 		if !reflect.DeepEqual(measurements, tt.want) {
 			t.Errorf("%q. parseMdstat() = %v, want %v", tt.name, measurements, tt.want)

--- a/system.go
+++ b/system.go
@@ -18,7 +18,6 @@ import (
 )
 
 var (
-	unameTimeout    = 5 * time.Second
 	cpuInfoTimeout  = 10 * time.Second
 	hostInfoTimeout = 10 * time.Second
 )


### PR DESCRIPTION
All warnings fixed:

```
$ golangci-lint run  -c .golangci.yml --skip-dirs vendor/

raid.go:48:44: parseMdstat - result 1 (error) is always nil (unparam)
func parseMdstat(data string) (RaidArrays, error) {
                                           ^

handler.go:187:1: cyclomatic complexity 29 of func `(*Cagent).GetAllMeasurements` is high (> 25) (gocyclo)
func (ca *Cagent) GetAllMeasurements() (common.MeasurementsMap, error) {
^

system.go:21:2: `unameTimeout` is unused (deadcode)
        unameTimeout    = 5 * time.Second
        ^

cmd/cagent/main.go:561:21: Error return value of `cmd.Process.Release` is not checked (errcheck)
        cmd.Process.Release()
                           ^

log.go:73:15: SA4006: this value of `err` is never used (staticcheck)
        plainformat, err := hook.formatter.Format(entry)
                     ^

raid.go:25:14: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
var failed = regexp.MustCompile("\\[([U_]+)\\]")

```


```
$ go vet ./...
# github.com/cloudradar-monitoring/cagent
./network.go:152:7: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
```