### PR TITLE
spk: force build static binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2
 docker_job_setup: &docker_job
   docker:
-    - image: cloudradario/go-build:0.0.14
+    - image: cloudradario/go-build:0.0.15
   working_directory: /go/src/github.com/cloudradar-monitoring/cagent
 
 attach_workspace: &workspace

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ windows-sign:
 	# Create remote build dir
 	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 mkdir -p /cygdrive/C/Users/hero/ci/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/dist
 	# Copy exe files to Windows VM for bundingling and signing
-	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/cagent/dist/windows_386/cagent.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/cagent_386.exe
-	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/cagent/dist/windows_amd64/cagent.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/cagent_64.exe
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/cagent/dist/cagent_windows_386/cagent.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/cagent_386.exe
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/cagent/dist/cagent_windows_amd64/cagent.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/cagent_64.exe
 	# Copy other build dependencies
 	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/cagent/build-win.bat hero@144.76.9.139:/cygdrive/C/Users/hero/ci/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat
 	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 chmod +x /cygdrive/C/Users/hero/ci/cagent_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat

--- a/synology-spk/create_spk.sh
+++ b/synology-spk/create_spk.sh
@@ -7,13 +7,15 @@ if [ -z "$1" ]
 fi
 
 
+# IMPORTANT: CGO_ENABLED=0 is used to force binaries to be statically linked
+
 # ARMv7
 sed -i.bak "s/{PKG_VERSION}/$1/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 sed -i.bak "s/{PKG_ARCH}/noarch/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 
-GOOS=linux GOARCH=arm GOARM=7 go build github.com/cloudradar-monitoring/cagent/cmd/cagent/...
+CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build github.com/cloudradar-monitoring/cagent/cmd/cagent/...
 mv -f cagent 1_create_package/cagent
 
 cd 1_create_package
@@ -34,7 +36,7 @@ rm 2_create_project/INFO.bak
 sed -i.bak "s/{PKG_ARCH}/noarch/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 
-GOOS=linux GOARCH=arm64 go build github.com/cloudradar-monitoring/cagent/cmd/cagent/...
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build github.com/cloudradar-monitoring/cagent/cmd/cagent/...
 mv -f cagent 1_create_package/cagent
 
 cd 1_create_package
@@ -55,7 +57,7 @@ rm 2_create_project/INFO.bak
 sed -i.bak "s/{PKG_ARCH}/x86_64 cedarview bromolow broadwell/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 
-GOOS=linux GOARCH=amd64 go build github.com/cloudradar-monitoring/cagent/cmd/cagent/...
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build github.com/cloudradar-monitoring/cagent/cmd/cagent/...
 mv -f cagent 1_create_package/cagent
 
 cd 1_create_package


### PR DESCRIPTION
Turns out circleci produced shared binaries which did not work in Synology DSM.

Using CGO_ENABLED=0 we force the binary to be statically linked.

Also update gobuild and some circleci tweaks

Follow-up to DEV-1117
Corresponding frontman pr: https://github.com/cloudradar-monitoring/frontman/pull/99/