### PR TITLE
Update 'bytes per second' calculation for windows.

### DIFF
--- a/config.go
+++ b/config.go
@@ -335,7 +335,7 @@ func (cfg *Config) GetParsedNetInterfaceMaxSpeed() (uint64, error) {
 		return 0, err
 	}
 	if value <= 0.0 {
-		return 0, fmt.Errorf("should be >= 0.0")
+		return 0, fmt.Errorf("should be > 0.0")
 	}
 
 	switch unit {

--- a/example.config.toml
+++ b/example.config.toml
@@ -43,6 +43,13 @@ net_interface_exclude_disconnected = true # default true
 net_interface_exclude_loopback = true # default true
 net_metrics = ['in_B_per_s', 'out_B_per_s', 'errors_per_s','dropped_per_s'] # default['in_B_per_s', 'out_B_per_s']
 
+# If the value is not specified, cagent will try to query the maximum speed of the network cards to calculate the bandwidth usage (default)
+# Depending on the network card type this is not always reliable.
+# Some virtual network cards, for example, report a maximum speed lower than the real speed.
+# You can set a fixed value by using <number of Bytes per second> + <K, M or G as a quantifier>.
+# Examples: "125M" (equals 1 GigaBit), "12.5M" (equals 100 MegaBits), "12.5G" (equals 100 GigaBit)
+net_interface_max_speed = ""
+
 # System
 system_fields = ['uname','os_kernel','os_family','os_arch','cpu_model','fqdn','memory_total_B'] # default ['uname','os_kernel','os_family','os_arch','cpu_model','fqdn','memory_total_B']
 

--- a/network.go
+++ b/network.go
@@ -1,6 +1,8 @@
 package cagent
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/networking"
 )
 
@@ -9,7 +11,10 @@ func (ca *Cagent) GetNetworkWatcher() *networking.NetWatcher {
 		return ca.netWatcher
 	}
 
-	maxSpeed, _ := ca.Config.GetParsedNetInterfaceMaxSpeed()
+	maxSpeed, err := ca.Config.GetParsedNetInterfaceMaxSpeed()
+	if err != nil {
+		logrus.Errorf("invalid net_interface_max_speed value supplied: %s. network max speed will be detected automatically.", err.Error())
+	}
 	ca.netWatcher = networking.NewWatcher(
 		networking.NetWatcherConfig{
 			NetInterfaceExclude:             ca.Config.NetInterfaceExclude,

--- a/network.go
+++ b/network.go
@@ -9,6 +9,7 @@ func (ca *Cagent) GetNetworkWatcher() *networking.NetWatcher {
 		return ca.netWatcher
 	}
 
+	maxSpeed, _ := ca.Config.GetParsedNetInterfaceMaxSpeed()
 	ca.netWatcher = networking.NewWatcher(
 		networking.NetWatcherConfig{
 			NetInterfaceExclude:             ca.Config.NetInterfaceExclude,
@@ -16,6 +17,7 @@ func (ca *Cagent) GetNetworkWatcher() *networking.NetWatcher {
 			NetInterfaceExcludeDisconnected: ca.Config.NetInterfaceExcludeDisconnected,
 			NetInterfaceExcludeLoopback:     ca.Config.NetInterfaceExcludeLoopback,
 			NetMetrics:                      ca.Config.NetMetrics,
+			NetInterfaceMaxSpeed:            maxSpeed,
 		},
 	)
 	return ca.netWatcher

--- a/pkg/monitoring/networking/net_notwindows.go
+++ b/pkg/monitoring/networking/net_notwindows.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package networking
+
+import (
+	"context"
+	"time"
+
+	utilnet "github.com/shirou/gopsutil/net"
+)
+
+const netGetCountersTimeout = time.Second * 10
+
+func getNetworkIOCounters() ([]utilnet.IOCountersStat, error) {
+	ctx, cancelFn := context.WithTimeout(context.Background(), netGetCountersTimeout)
+	defer cancelFn()
+	return utilnet.IOCountersWithContext(ctx, true)
+}

--- a/pkg/winapi/iphlpapi.go
+++ b/pkg/winapi/iphlpapi.go
@@ -14,8 +14,14 @@ var (
 	modiphlpapi = windows.NewLazySystemDLL("iphlpapi.dll")
 
 	procGetAdaptersAddresses = modiphlpapi.NewProc("GetAdaptersAddresses")
+	procGetIfEntry2          = modiphlpapi.NewProc("GetIfEntry2")
 )
 
+const (
+	IF_MAX_PHYS_ADDRESS_LENGTH = 32
+)
+
+// IP_ADAPTER_ADDRESSES_LH
 // https://docs.microsoft.com/ru-ru/windows/win32/api/iptypes/ns-iptypes-_ip_adapter_addresses_lh
 type IPAdapterAddresses struct {
 	Length                uint32
@@ -41,6 +47,68 @@ type IPAdapterAddresses struct {
 	TransmitLinkSpeed     uint64
 	ReceiveLinkSpeed      uint64
 	/* more fields might be present here. */
+}
+
+type NET_LUID NET_LUID_LH
+type NET_LUID_LH struct {
+	Value uint64
+}
+
+type NET_IF_GUID struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]byte
+}
+
+// GUID
+type NET_IF_NETWORK_GUID NET_IF_GUID
+
+// MIB_IF_ROW2
+// https://docs.microsoft.com/ru-ru/windows/win32/api/netioapi/ns-netioapi-_mib_if_row2
+type MibIfRow2 struct {
+	InterfaceLuid               NET_LUID
+	InterfaceIndex              uint32
+	InterfaceGuid               NET_IF_GUID
+	Alias                       [windows.MAX_ADAPTER_NAME_LENGTH + 1]uint16
+	Description                 [windows.MAX_ADAPTER_NAME_LENGTH + 1]uint16
+	PhysicalAddressLength       uint32
+	PhysicalAddress             [IF_MAX_PHYS_ADDRESS_LENGTH]byte
+	PermanentPhysicalAddress    [IF_MAX_PHYS_ADDRESS_LENGTH]byte
+	Mtu                         uint32
+	Type                        uint32
+	TunnelType                  int32
+	MediaType                   int32
+	PhysicalMediumType          int32
+	AccessType                  int32
+	DirectionType               int32
+	InterfaceAndOperStatusFlags bool
+	OperStatus                  int32
+	AdminStatus                 int32
+	MediaConnectState           int32
+	NetworkGuid                 NET_IF_NETWORK_GUID
+	ConnectionType              int32
+	padding1                    [pad0for64_4for32]byte
+	TransmitLinkSpeed           uint64
+	ReceiveLinkSpeed            uint64
+	InOctets                    uint64
+	InUcastPkts                 uint64
+	InNUcastPkts                uint64
+	InDiscards                  uint64
+	InErrors                    uint64
+	InUnknownProtos             uint64
+	InUcastOctets               uint64
+	InMulticastOctets           uint64
+	InBroadcastOctets           uint64
+	OutOctets                   uint64
+	OutUcastPkts                uint64
+	OutNUcastPkts               uint64
+	OutDiscards                 uint64
+	OutErrors                   uint64
+	OutUcastOctets              uint64
+	OutMulticastOctets          uint64
+	OutBroadcastOctets          uint64
+	OutQLen                     uint64
 }
 
 func (a *IPAdapterAddresses) GetInterfaceName() string {
@@ -78,11 +146,11 @@ func GetAdaptersAddresses() ([]*IPAdapterAddresses, error) {
 		}
 
 		if err.(syscall.Errno) != syscall.ERROR_BUFFER_OVERFLOW {
-			return nil, os.NewSyscallError("getadaptersaddresses", err)
+			return nil, os.NewSyscallError("GetAdaptersAddresses", err)
 		}
 
 		if l <= uint32(len(b)) {
-			return nil, os.NewSyscallError("getadaptersaddresses", err)
+			return nil, os.NewSyscallError("GetAdaptersAddresses", err)
 		}
 	}
 	var aas []*IPAdapterAddresses
@@ -90,4 +158,16 @@ func GetAdaptersAddresses() ([]*IPAdapterAddresses, error) {
 		aas = append(aas, aa)
 	}
 	return aas, nil
+}
+
+// https://docs.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-getifentry2
+// On input, the InterfaceLuid or the InterfaceIndex member of the MibIfRow2 must be set to the interface for which to retrieve information.
+func GetIfEntry2(row *MibIfRow2) error {
+	r0, _, _ := syscall.Syscall(procGetIfEntry2.Addr(), 1, uintptr(unsafe.Pointer(row)), 0, 0)
+	if r0 != 0 {
+		err := syscall.Errno(r0)
+		return os.NewSyscallError("GetIfEntry2", err)
+	}
+
+	return nil
 }

--- a/pkg/winapi/win_386.go
+++ b/pkg/winapi/win_386.go
@@ -1,0 +1,6 @@
+// +build windows
+// +build 386
+
+package winapi
+
+const pad0for64_4for32 = 4

--- a/pkg/winapi/win_amd64.go
+++ b/pkg/winapi/win_amd64.go
@@ -1,0 +1,6 @@
+// +build windows
+// +build amd64
+
+package winapi
+
+const pad0for64_4for32 = 0


### PR DESCRIPTION
DEV-1039.

1) Update 'bytes per second' calculation for windows.
The old implementation could return incorrect value due to errors in underlying library (gopsutil).

2) Add config field to set fixed value for max network link speed.
