### PR TITLE
Fix minor golangci-lint warnings for windows code

### DIFF
--- a/mem_windows.go
+++ b/mem_windows.go
@@ -18,13 +18,11 @@ import (
 const memGetTimeout = time.Second * 10
 
 func (ca *Cagent) MemResults() (common.MeasurementsMap, *mem.VirtualMemoryStat, error) {
-	results := common.MeasurementsMap{}
-
 	var errs []string
 	ctx, cancel := context.WithTimeout(context.Background(), memGetTimeout)
 	defer cancel()
 
-	results = map[string]interface{}{
+	results := map[string]interface{}{
 		"total_B":           nil,
 		"free_B":            nil,
 		"free_percent":      nil,

--- a/perfcounters/pdh.go
+++ b/perfcounters/pdh.go
@@ -37,8 +37,9 @@ import (
 	"syscall"
 	"unsafe"
 
-	"golang.org/x/sys/windows"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 // Error codes
@@ -160,7 +161,7 @@ const (
 )
 
 type (
-	PDH_HQUERY   HANDLE // query handle
+	PDH_HQUERY HANDLE   // query handle
 	PDH_HCOUNTER HANDLE // counter handle
 )
 
@@ -327,8 +328,7 @@ func PdhCollectQueryDataWithTime(hQuery PDH_HQUERY) (uint32, time.Time) {
 
 		// First convert 100-ns intervals to microseconds, then adjust for the
 		// epoch difference
-		var totalMicroSeconds int64
-		totalMicroSeconds = ((int64(utcFileTime.dwHighDateTime) << 32) | int64(utcFileTime.dwLowDateTime)) / 10
+		var totalMicroSeconds = ((int64(utcFileTime.dwHighDateTime) << 32) | int64(utcFileTime.dwLowDateTime)) / 10
 		totalMicroSeconds -= EPOCH_DIFFERENCE_MICROS
 
 		retTime := time.Unix(0, totalMicroSeconds*1000)

--- a/pkg/hwinfo/hwinfo_windows.go
+++ b/pkg/hwinfo/hwinfo_windows.go
@@ -52,7 +52,7 @@ func fetchInventory() (map[string]interface{}, error) {
 		res = common.MergeStringMaps(res, baseboardInfo)
 	}
 
-	ramInfo, err := getRamInfo()
+	ramInfo, err := getRAMInfo()
 	errorCollector.Add(err)
 	if len(ramInfo) > 0 {
 		res = common.MergeStringMaps(res, ramInfo)
@@ -257,7 +257,7 @@ func getBaseboardInfo() (map[string]interface{}, error) {
 	return res, nil
 }
 
-func getRamInfo() (map[string]interface{}, error) {
+func getRAMInfo() (map[string]interface{}, error) {
 	var ram []win32_PhysicalMemory
 	query := wmi.CreateQuery(&ram, "")
 	if err := wmi.Query(query, &ram); err != nil {

--- a/pkg/monitoring/docker/docker_windows.go
+++ b/pkg/monitoring/docker/docker_windows.go
@@ -8,10 +8,10 @@ func New() (*Watcher, error) {
 	return nil, ErrorNotImplementedForOS
 }
 
-func (_ *Watcher) ListContainers() (map[string]interface{}, error) {
+func (*Watcher) ListContainers() (map[string]interface{}, error) {
 	return nil, ErrorNotImplementedForOS
 }
 
-func (_ *Watcher) ContainerNameByID(_ string) (string, error) {
+func (*Watcher) ContainerNameByID(_ string) (string, error) {
 	return "", ErrorNotImplementedForOS
 }

--- a/pkg/monitoring/services/services_windows.go
+++ b/pkg/monitoring/services/services_windows.go
@@ -6,11 +6,12 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/cloudradar-monitoring/cagent/pkg/winapi"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/winapi"
 )
 
 type serviceInfo struct {

--- a/pkg/monitoring/top/top_windows.go
+++ b/pkg/monitoring/top/top_windows.go
@@ -35,7 +35,7 @@ func (t *Top) GetProcesses(interval time.Duration) ([]*ProcessInfoSnapshot, erro
 			info := &ProcessInfoSnapshot{
 				Name:      newProcessInfo.ImageName.String(),
 				PID:       pid,
-				ParentPID: uint32(newProcessInfo.InheritedFromUniqueProcessId),
+				ParentPID: uint32(newProcessInfo.InheritedFromUniqueProcessID),
 				Command:   "",
 				Load:      winapi.CalculateProcessCPUUsagePercent(oldProcessInfo, newProcessInfo, timeElapsedReal, t.logicalCPUCount),
 			}

--- a/pkg/winapi/ntdll.go
+++ b/pkg/winapi/ntdll.go
@@ -123,7 +123,7 @@ func GetSystemProcessInformation() (map[uint32]*SystemProcessInformation, error)
 	var counter int
 	result := make(map[uint32]*SystemProcessInformation)
 	for {
-		result[uint32((*p).UniqueProcessId)] = p
+		result[uint32((*p).UniqueProcessID)] = p
 		counter++
 		if p.NextEntryOffset == 0 {
 			break

--- a/pkg/winapi/types.go
+++ b/pkg/winapi/types.go
@@ -78,10 +78,10 @@ type SystemProcessInformation struct {
 	KernelTime                   int64         // LARGE_INTEGER
 	ImageName                    unicodeString // UNICODE_STRING
 	BasePriority                 kPriority     // KPRIORITY
-	UniqueProcessId              uintptr       // HANDLE
-	InheritedFromUniqueProcessId uintptr       // HANDLE
+	UniqueProcessID              uintptr       // HANDLE
+	InheritedFromUniqueProcessID uintptr       // HANDLE
 	HandleCount                  uint32        // ULONG
-	SessionId                    uint32        // ULONG
+	SessionID                    uint32        // ULONG
 	UniqueProcessKey             *uint32       // ULONG_PTR
 	PeakVirtualSize              uintptr       // SIZE_T
 	VirtualSize                  uintptr       // SIZE_T
@@ -119,7 +119,7 @@ type systemThreadInformation struct {
 	CreateTime      int64       // LARGE_INTEGER
 	WaitTime        uint32      // ULONG
 	StartAddress    uintptr     // PVOID
-	ClientId        clientID    // CLIENT_ID
+	ClientID        clientID    // CLIENT_ID
 	Priority        kPriority   // KPRIORITY
 	BasePriority    int32       // LONG
 	ContextSwitches uint32      // ULONG
@@ -134,7 +134,7 @@ type processBasicInformation struct {
 	AffinityMask                 uintptr
 	BasePriority                 int32
 	UniqueProcessID              uintptr
-	InheritedFromUniqueProcessId uintptr
+	InheritedFromUniqueProcessID uintptr
 }
 
 // SERVICE_DELAYED_AUTO_START_INFO

--- a/processes_windows.go
+++ b/processes_windows.go
@@ -54,7 +54,7 @@ func processes(_ *docker.Watcher, systemMemorySize uint64) ([]ProcStat, error) {
 		memoryUsagePercent := (float64(proc.WorkingSetSize) / float64(systemMemorySize)) * 100
 		ps := ProcStat{
 			PID:                    int(pid),
-			ParentPID:              int(proc.InheritedFromUniqueProcessId),
+			ParentPID:              int(proc.InheritedFromUniqueProcessID),
 			State:                  "running",
 			Name:                   proc.ImageName.String(),
 			Cmdline:                cmdLine,

--- a/windows.go
+++ b/windows.go
@@ -132,7 +132,7 @@ func windowsUpdates() (available int, pending int, lastTimeUpdated time.Time, er
 
 		resultCode, err := oleutil.GetProperty(item, "ResultCode")
 		if err != nil {
-			// On Win10 machine returns "Exception occured." after 75 updates so it looks like some undocumented internal limit.
+			// On Win10 machine returns "Exception occurred." after 75 updates so it looks like some undocumented internal limit.
 			// We only need the last ones to found "Pending" updates so just ignore this error
 			continue
 		}


### PR DESCRIPTION
(use GOOS=windows to execute it on windows code).

Not all warnings fixed.