### PR TITLE
Add meaningful description of installed cagent service

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -32,8 +32,8 @@ var (
 
 var svcConfig = &service.Config{
 	Name:        "cagent",
-	DisplayName: "Cagent",
-	Description: "Monitoring agent for system metrics",
+	DisplayName: "CloudRadar Monitoring Agent",
+	Description: "A versatile monitoring agent developed by cloudradar.io. It monitors your local operating system.",
 }
 
 func askForConfirmation(s string) bool {

--- a/pkg-scripts/msi-templates/product.wxs
+++ b/pkg-scripts/msi-templates/product.wxs
@@ -73,7 +73,16 @@
                         <RemoveFolder Id="CleanApplicationFolders" Directory="ApplicationProgramsFolder" On="uninstall"/>
                         {{range $i, $e := .Files.Items}}
                             {{if eq $i 0}}
-                                <ServiceInstall Id="ServiceInstaller" Name="Cagent" Type="ownProcess" Vital="yes" DisplayName="Cagent" Description="Cagent" Start="auto" Account="LocalSystem" ErrorControl="normal" Interactive="no">
+                                <ServiceInstall Id="ServiceInstaller"
+                                    Name="Cagent"
+                                    Type="ownProcess"
+                                    Vital="yes"
+                                    DisplayName="CloudRadar Monitoring Agent"
+                                    Description="A versatile monitoring agent developed by cloudradar.io. It monitors your local operating system."
+                                    Start="auto"
+                                    Account="LocalSystem"
+                                    ErrorControl="normal"
+                                    Interactive="no">
                                 </ServiceInstall>
                                 <ServiceControl Id="StartService" Name="Cagent" Stop="both" Start="install" Remove="uninstall" Wait="yes">
                                     <ServiceArgument />


### PR DESCRIPTION
Shown in "Services" on Windows and in the output of "service cagent status" command on Linux systems.