### PR TITLE
Exclude armv6 deb package from Aptly repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ aptly:
 	# Create remote work dir
 	ssh -p 24480 -oStrictHostKeyChecking=no cr@repo.cloudradar.io mkdir -p /home/cr/work/aptly/${CIRCLE_BUILD_NUM}
 	# Upload deb files
-	rsync -e 'ssh -oStrictHostKeyChecking=no -p 24480' --recursive ${PROJECT_DIR}/dist/*.deb  cr@repo.cloudradar.io:/home/cr/work/aptly/${CIRCLE_BUILD_NUM}/
+	rsync -e 'ssh -oStrictHostKeyChecking=no -p 24480' --recursive ${PROJECT_DIR}/dist/*.deb --exclude "*_armv6.deb"  cr@repo.cloudradar.io:/home/cr/work/aptly/${CIRCLE_BUILD_NUM}/
 	# Trigger repository update
 	ssh -p 24480 -oStrictHostKeyChecking=no cr@repo.cloudradar.io /home/cr/work/aptly/update_repo.sh /home/cr/work/aptly/${CIRCLE_BUILD_NUM} ${CIRCLE_TAG}
 


### PR DESCRIPTION
Debian policy does not allow adding packages with the same (name, arch, version) into one repository.
armv6 and armv7 produce the same architecture 'armhf' which causes the aptly to add only one package to the repo and spit out a warning.

DEV-1076