### PR TITLE
Update package build to recommend dependant tools instead of hard requirement

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,19 +84,18 @@ nfpm:
   - rpm
 
   dependencies:
-  - dmidecode
-  - usbutils
   - sudo
 
-  # Recommend to install root SSL certificates
   recommends:
+  - dmidecode
+  - usbutils
   - ca-certificates
+  - dbus
 
   # Override default /usr/local/bin destination for binaries
   bindir: /usr/bin
 
-  # Empty folders that should be created and managed by the packager
-  # implementation.
+  # Empty folders that should be created and managed by the packager implementation.
   empty_folders:
   - /var/log/cagent
   - /etc/cagent

--- a/pkg-scripts/cagent-dmidecode
+++ b/pkg-scripts/cagent-dmidecode
@@ -1,3 +1,3 @@
-# configuration to allow cagent run demidecode command
+# configuration to allow cagent run dmidecode command
 
 cagent ALL= NOPASSWD: /usr/sbin/dmidecode

--- a/pkg/hwinfo/hwinfo_nonwindows.go
+++ b/pkg/hwinfo/hwinfo_nonwindows.go
@@ -17,8 +17,8 @@ import (
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
 )
 
-func isCommandAvailable(name string) bool {
-	cmd := exec.Command("/bin/sh", "-c", "command", "-v", name)
+func isDmidecodeAvailable() bool {
+	cmd := exec.Command("/bin/sh", "-c", "command -v dmidecode")
 	if err := cmd.Run(); err != nil {
 		return false
 	}
@@ -64,7 +64,7 @@ func fetchInventory() (map[string]interface{}, error) {
 }
 
 func retrieveInfoUsingDmiDecode() (map[string]interface{}, error) {
-	if !isCommandAvailable("dmidecode") {
+	if !isDmidecodeAvailable() {
 		log.Infof("[HWINFO] dmidecode is not present. Skipping retrieval of baseboard, CPU and RAM info...")
 		return nil, nil
 	}

--- a/pkg/monitoring/services/services_nonwindows.go
+++ b/pkg/monitoring/services/services_nonwindows.go
@@ -418,8 +418,12 @@ func listSysVAndUpstartServicesCombined() []map[string]string {
 	if isUpstart() {
 		upstartServices, err := ListUpstartServices()
 		if err != nil {
-			// in case of error lets try to query other
-			log.Errorf("[Services] Upstart: failed to list a services via initctl: %s", err.Error())
+			if strings.Contains(err.Error(), "dbus") {
+				log.Info("[Services] Upstart: monitoring of service might be incomplete due to missing dbus. Try to install the dbus package.")
+				log.WithError(err).Debugf("[Services] Upstart: while calling initctl, encountered dbus error")
+			} else {
+				log.WithError(err).Error("[Services] Upstart: failed to list a services via initctl")
+			}
 		}
 
 		for _, service := range upstartServices {


### PR DESCRIPTION
Also:
- add dbus to the list of recommended packages: DEV-1177
- fix dmidecode detection. Now info message will be logged instead of an error