### PR TITLE
Set default log level explicitly

### DIFF
--- a/config.go
+++ b/config.go
@@ -174,7 +174,7 @@ func NewConfig() *Config {
 		},
 	}
 
-	cfg.MinValuableConfig.IOMode = IOModeHTTP
+	cfg.MinValuableConfig = *(defaultMinValuableConfig())
 
 	if runtime.GOOS == "windows" {
 		cfg.WindowsUpdatesWatcherInterval = 3600
@@ -190,10 +190,7 @@ func NewConfig() *Config {
 }
 
 func NewMinimumConfig() *MinValuableConfig {
-	cfg := &MinValuableConfig{
-		LogLevel: "error",
-		IOMode:   IOModeHTTP,
-	}
+	cfg := defaultMinValuableConfig()
 
 	cfg.applyEnv(false)
 
@@ -209,6 +206,13 @@ func NewMinimumConfig() *MinValuableConfig {
 	}
 
 	return cfg
+}
+
+func defaultMinValuableConfig() *MinValuableConfig {
+	return &MinValuableConfig{
+		LogLevel: LogLevelError,
+		IOMode:   IOModeHTTP,
+	}
 }
 
 func secToDuration(secs float64) time.Duration {

--- a/config_test.go
+++ b/config_test.go
@@ -24,6 +24,7 @@ func TestNewMinimumConfig(t *testing.T) {
 	assert.Equal(t, envURL, mvc.HubURL, "HubURL should be set from env")
 	assert.Equal(t, envUser, mvc.HubUser, "HubUser should be set from env")
 	assert.Equal(t, envPass, mvc.HubPassword, "HubPassword should be set from env")
+	assert.Equal(t, LogLevelError, mvc.LogLevel, "default log level should be error")
 
 	// Unset in the end for cleanup
 	defer os.Clearenv()


### PR DESCRIPTION
There was an error when the log level wasn't set at all, causing cagent to use `info` instead of `error`