### PR TITLE
Remove 'core_enabled' metric for CPU info

### DIFF
--- a/pkg/hwinfo/hwinfo_darwin.go
+++ b/pkg/hwinfo/hwinfo_darwin.go
@@ -20,7 +20,6 @@ type cpuInfo struct {
 	manufacturingInfo string
 	description       string
 	coreCount         string
-	coreEnabled       string
 	threadCount       string
 }
 
@@ -104,8 +103,6 @@ func listCPUs() (map[string]interface{}, error) {
 			c.description = strings.Join(values[1:], " ")
 		case strings.HasPrefix(line, "machdep.cpu.thread_count"):
 			c.threadCount = values[1]
-		case strings.HasPrefix(line, "machdep.cpu.core_count"):
-			c.coreEnabled = values[1]
 		case strings.HasPrefix(line, "machdep.cpu.cores_per_package"):
 			c.coreCount = values[1]
 		case strings.HasPrefix(line, "machdep.cpu.family"):
@@ -135,7 +132,6 @@ func listCPUs() (map[string]interface{}, error) {
 		encodedCpus[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = parsedCPUs[i].manufacturingInfo
 		encodedCpus[fmt.Sprintf("cpu.%d.description", i)] = parsedCPUs[i].description
 		encodedCpus[fmt.Sprintf("cpu.%d.core_count", i)] = parsedCPUs[i].coreCount
-		encodedCpus[fmt.Sprintf("cpu.%d.core_enabled", i)] = parsedCPUs[i].coreEnabled
 		encodedCpus[fmt.Sprintf("cpu.%d.thread_count", i)] = parsedCPUs[i].threadCount
 	}
 

--- a/pkg/hwinfo/hwinfo_other.go
+++ b/pkg/hwinfo/hwinfo_other.go
@@ -419,7 +419,6 @@ func encodeCPUs(cpus []cpuStat) map[string]interface{} {
 			encodedCpus[fmt.Sprintf("cpu.%s.manufacturing_info", cpu.PhysicalID)] = fmt.Sprintf("Model %s Family %s Stepping %d", cpu.Model, cpu.Family, cpu.Stepping)
 			encodedCpus[fmt.Sprintf("cpu.%s.description", cpu.PhysicalID)] = cpu.ModelName
 			encodedCpus[fmt.Sprintf("cpu.%s.core_count", cpu.PhysicalID)] = fmt.Sprintf("%d", cpu.Cores)
-			encodedCpus[fmt.Sprintf("cpu.%s.core_enabled", cpu.PhysicalID)] = fmt.Sprintf("%d", cpu.Cores)
 			encodedCpus[fmt.Sprintf("cpu.%s.thread_count", cpu.PhysicalID)] = fmt.Sprintf("%d", cpu.Siblings)
 		}
 	}

--- a/pkg/hwinfo/hwinfo_windows.go
+++ b/pkg/hwinfo/hwinfo_windows.go
@@ -233,7 +233,6 @@ func getCPUInfo() (map[string]interface{}, error) {
 		res[fmt.Sprintf("cpu.%d.manufacturing_info", i)] = cpus[i].Description
 		res[fmt.Sprintf("cpu.%d.description", i)] = cpus[i].Name
 		res[fmt.Sprintf("cpu.%d.core_count", i)] = cpus[i].NumberOfCores
-		res[fmt.Sprintf("cpu.%d.core_enabled", i)] = cpus[i].NumberOfEnabledCore
 		res[fmt.Sprintf("cpu.%d.thread_count", i)] = cpus[i].NumberOfLogicalProcessors
 	}
 

--- a/pkg/hwinfo/wmi_types.go
+++ b/pkg/hwinfo/wmi_types.go
@@ -24,7 +24,6 @@ type win32_Processor struct {
 	Name                      *string
 	Manufacturer              *string
 	NumberOfCores             *uint32
-	NumberOfEnabledCore       *uint32
 	NumberOfLogicalProcessors *uint32
 }
 


### PR DESCRIPTION
It was working properly only for Windows 10 and above.
Windows Server 2008 was crashing here due to implementation.
Other systems reported incorrect values.

More details: DEV-1253