### PR TITLE
Fix error working with NaN value

### DIFF
--- a/pkg/monitoring/networking/net_linux.go
+++ b/pkg/monitoring/networking/net_linux.go
@@ -30,5 +30,9 @@ func (p *linuxLinkSpeedProvider) GetMaxAvailableLinkSpeed(ifName string) (float6
 		return 0, errors.Wrap(err, "invalid data in speed info file")
 	}
 
+	if megaBitsPerSecond < 0 {
+		return 0, fmt.Errorf("got unexpected speed value: %s", strData)
+	}
+
 	return float64(megaBitsPerSecond) / 8 * 1000 * 1000, nil
 }


### PR DESCRIPTION
Some network cards can report "-1" link speed on linux. Old code ignored this leading to 0.0/0.0 -> NaN, which could not be serialized to JSON result object