### PR TITLE
Make FS monitoring to detect network volumes FS type on Windows

### DIFF
--- a/config.go
+++ b/config.go
@@ -78,7 +78,7 @@ type Config struct {
 	CPUUtilDataGather []string `toml:"cpu_utilisation_gathering_mode" comment:"default ['avg1']"`
 	CPUUtilTypes      []string `toml:"cpu_utilisation_types" comment:"default ['user','system','idle','iowait']"`
 
-	FSTypeInclude        []string `toml:"fs_type_include" comment:"default ['ext3','ext4','xfs','jfs','ntfs','btrfs','hfs','apfs','fat32']"`
+	FSTypeInclude        []string `toml:"fs_type_include" comment:"default ['ext3','ext4','xfs','jfs','ntfs','btrfs','hfs','apfs','fat32','smbfs','nfs']"`
 	FSPathExclude        []string `toml:"fs_path_exclude" comment:"Exclude file systems by name, disabled by default"`
 	FSPathExcludeRecurse bool     `toml:"fs_path_exclude_recurse" comment:"Having fs_path_exclude_recurse = false the specified path must match a mountpoint or it will be ignored\nHaving fs_path_exclude_recurse = true the specified path can be any folder and all mountpoints underneath will be excluded"`
 
@@ -159,7 +159,7 @@ func NewConfig() *Config {
 		CPULoadDataGather:                []string{"avg1"},
 		CPUUtilTypes:                     []string{"user", "system", "idle", "iowait"},
 		CPUUtilDataGather:                []string{"avg1"},
-		FSTypeInclude:                    []string{"ext3", "ext4", "xfs", "jfs", "ntfs", "btrfs", "hfs", "apfs", "fat32"},
+		FSTypeInclude:                    []string{"ext3", "ext4", "xfs", "jfs", "ntfs", "btrfs", "hfs", "apfs", "fat32", "smbfs", "nfs"},
 		FSPathExclude:                    []string{},
 		FSPathExcludeRecurse:             false,
 		FSMetrics:                        []string{"free_B", "free_percent", "total_B", "read_B_per_s", "write_B_per_s", "read_ops_per_s", "write_ops_per_s"},

--- a/example.config.toml
+++ b/example.config.toml
@@ -32,7 +32,7 @@ cpu_utilisation_gathering_mode = ['avg1','avg5','avg15'] # default ['avg1']
 cpu_utilisation_types = ['user','system','nice','idle','iowait','interrupt','softirq','steal'] # default ['user','system','idle','iowait']
 
 # FS
-fs_type_include = ['ext3','ext4','xfs','jfs','ntfs','btrfs','hfs','apfs','fat32'] # default ['ext3','ext4','xfs','jfs','ntfs','btrfs','hfs','apfs','fat32']
+fs_type_include = ['ext4','xfs','jfs'] # default ['ext3','ext4','xfs','jfs','ntfs','btrfs','hfs','apfs','fat32','smbfs','nfs']
 fs_path_exclude = ['/mnt/*','h:'] # default []
 fs_metrics = ['free_B','free_percent','used_B','used_percent','total_B','inodes_total','inodes_free','inodes_used','inodes_used_percent','read_B_per_s','write_B_per_s','read_ops_per_s','write_ops_per_s']
 

--- a/pkg/monitoring/fs/fs_notwindows.go
+++ b/pkg/monitoring/fs/fs_notwindows.go
@@ -9,6 +9,13 @@ import (
 	"github.com/shirou/gopsutil/disk"
 )
 
+func getPartitions() ([]disk.PartitionStat, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), fsInfoRequestTimeout)
+	defer cancel()
+
+	return disk.PartitionsWithContext(ctx, true)
+}
+
 func getPartitionIOCounters(deviceName string) (*disk.IOCountersStat, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), fsInfoRequestTimeout)
 	defer cancel()

--- a/pkg/monitoring/fs/fs_windows.go
+++ b/pkg/monitoring/fs/fs_windows.go
@@ -3,13 +3,126 @@
 package fs
 
 import (
+	"bytes"
+	"strings"
+	"unsafe"
+
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/cloudradar-monitoring/cagent/pkg/winapi"
 )
+
+const (
+	minDriveLabelChar = 65
+	maxDriveLabelChar = 90
+
+	driveTypeRemovable = 2
+	driveTypeFixed     = 3
+	driveTypeRemote    = 4
+	driveTypeCDROM     = 5
+)
+
+// getPartitions is an improved version of gopsutil/disk.GetPartitions()
+// which is capable of determining the fs type of network drives.
+func getPartitions() ([]disk.PartitionStat, error) {
+	var result []disk.PartitionStat
+	lpBuffer := make([]byte, 254)
+	bufferPtr := unsafe.Pointer(&lpBuffer[0])
+	diskret, err := windows.GetLogicalDriveStrings(uint32(len(lpBuffer)), (*uint16)(bufferPtr))
+	if diskret == 0 {
+		return result, err
+	}
+
+	for _, v := range lpBuffer {
+		if v >= minDriveLabelChar && v <= maxDriveLabelChar {
+			path := string(v) + ":"
+			typepath, _ := windows.UTF16PtrFromString(path)
+			typeret := windows.GetDriveType(typepath)
+			if typeret == 0 {
+				return result, windows.GetLastError()
+			}
+
+			if typeret == driveTypeRemovable || typeret == driveTypeFixed || typeret == driveTypeRemote || typeret == driveTypeCDROM {
+				lpVolumeNameBuffer := make([]byte, 256)
+				lpVolumeSerialNumber := int64(0)
+				lpMaximumComponentLength := int64(0)
+				lpFileSystemFlags := int64(0)
+				lpFileSystemNameBuffer := make([]byte, 256)
+				volpath, _ := windows.UTF16PtrFromString(string(v) + ":/")
+
+				err := windows.GetVolumeInformation(
+					volpath,
+					(*uint16)(unsafe.Pointer(&lpVolumeNameBuffer[0])),
+					uint32(len(lpVolumeNameBuffer)),
+					(*uint32)(unsafe.Pointer(&lpVolumeSerialNumber)),
+					(*uint32)(unsafe.Pointer(&lpMaximumComponentLength)),
+					(*uint32)(unsafe.Pointer(&lpFileSystemFlags)),
+					(*uint16)(unsafe.Pointer(&lpFileSystemNameBuffer[0])),
+					uint32(len(lpFileSystemNameBuffer)),
+				)
+				if err != nil {
+					if typeret == driveTypeCDROM || typeret == driveTypeRemovable {
+						continue // device is not ready will happen if there is no disk in the drive
+					}
+					return result, err
+				}
+				opts := "rw"
+				if lpFileSystemFlags&disk.FileReadOnlyVolume != 0 {
+					opts = "ro"
+				}
+				if lpFileSystemFlags&disk.FileFileCompression != 0 {
+					opts += ".compress"
+				}
+
+				fsType := string(bytes.Replace(lpFileSystemNameBuffer, []byte("\x00"), []byte(""), -1))
+				if typeret == driveTypeRemote {
+					remoteDriveType, err := tryRetrieveRemoteDriveFSType(typepath)
+					if err != nil {
+						return result, err
+					}
+					if remoteDriveType != "" {
+						fsType = remoteDriveType
+					}
+				}
+
+				d := disk.PartitionStat{
+					Mountpoint: path,
+					Device:     path,
+					Fstype:     fsType,
+					Opts:       opts,
+				}
+				result = append(result, d)
+			}
+		}
+	}
+	return result, nil
+}
+
+// tryRetrieveRemoteDriveFSType can detect the original network share filesystem.
+// If filesystem wasn't recognized, the empty string returned.
+// Based on some insights from cygwin implementation.
+func tryRetrieveRemoteDriveFSType(drivePath *uint16) (string, error) {
+	lpTargetBuffer := make([]byte, 256)
+	_, err := windows.QueryDosDevice(drivePath, (*uint16)(unsafe.Pointer(&lpTargetBuffer[0])), uint32(len(lpTargetBuffer)))
+	if err != nil {
+		return "", errors.Wrapf(err, "while QueryDosDevice call")
+	}
+
+	dosDeviceName := string(bytes.Replace(lpTargetBuffer, []byte("\x00"), []byte(""), -1))
+	if strings.Contains(dosDeviceName, "LanmanRedirector\\") {
+		return "smbfs", nil
+	}
+
+	if strings.Contains(dosDeviceName, "MRxNfs\\") {
+		return "nfs", nil
+	}
+
+	return "", nil
+}
 
 func getPartitionIOCounters(deviceName string) (*disk.IOCountersStat, error) {
 	if err := enablePerformanceCounters(); err != nil {


### PR DESCRIPTION
The old Windows implementation was returning 'NTFS' for all network shared volumes.
The Linux implementation is left untouched.

DEV-1250