### PR TITLE
Improve storcli reporting

### DIFF
--- a/config.go
+++ b/config.go
@@ -123,8 +123,7 @@ type CPUUtilisationAnalysisConfig struct {
 }
 
 type StorCLIConfig struct {
-	BinaryPath     string `toml:"binary" comment:"Enable on Windows:\n  binary = 'C:\\\\Program Files\\\\storcli\\\\storcli64.exe'\nEnable on Linux:\n  binary = '/opt/storcli/sbin/storcli64'"`
-	ControllerList []uint `toml:"controllers" comment:"controllers to monitor, comma separated. default: [0] (monitor only controller c0)"`
+	BinaryPath string `toml:"binary" comment:"Enable on Windows:\n  binary = 'C:\\\\Program Files\\\\storcli\\\\storcli64.exe'\nEnable on Linux:\n  binary = '/opt/storcli/sbin/storcli64'"`
 }
 
 func init() {
@@ -185,8 +184,7 @@ func NewConfig() *Config {
 			HubFile: "",
 		},
 		StorCLI: StorCLIConfig{
-			BinaryPath:     "",
-			ControllerList: []uint{0},
+			BinaryPath: "",
 		},
 	}
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -79,5 +79,3 @@ temperature_monitoring = true # default true
   #   binary = "C:\\Program Files\storcli\storcli64.exe"
   # Enable on Linux:
   binary = "/opt/storcli/sbin/storcli64"
-  # controllers list to monitor:
-  controllers = [0, 1]

--- a/handler.go
+++ b/handler.go
@@ -288,9 +288,9 @@ func (ca *Cagent) CollectMeasurements(full bool) (common.MeasurementsMap, error)
 			measurements = measurements.AddWithPrefix("temperatures.", common.MeasurementsMap{"list": temperatures})
 		}
 
-		modules, err := ca.collectModulesMeasurements()
+		moduleReports, err := ca.collectModulesMeasurements()
 		errCollector.Add(err)
-		measurements = measurements.AddWithPrefix("", common.MeasurementsMap{"modules": modules})
+		measurements = measurements.AddWithPrefix("", common.MeasurementsMap{"modules": moduleReports})
 
 		smartMeas := ca.getSMARTMeasurements()
 		if len(smartMeas) > 0 {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,5 +1,10 @@
 package common
 
+import (
+	"fmt"
+	"time"
+)
+
 type MeasurementsMap map[string]interface{}
 
 func (mm MeasurementsMap) AddWithPrefix(prefix string, m MeasurementsMap) MeasurementsMap {
@@ -13,4 +18,14 @@ func (mm MeasurementsMap) AddInnerWithPrefix(prefix string, m MeasurementsMap) M
 	mm[prefix] = m
 
 	return mm
+}
+
+// Timestamp type allows marshaling time.Time struct as Unix timestamp value
+type Timestamp time.Time
+
+func (t *Timestamp) MarshalJSON() ([]byte, error) {
+	ts := time.Time(*t).Unix()
+	stamp := fmt.Sprint(ts)
+
+	return []byte(stamp), nil
 }

--- a/pkg/monitoring/module.go
+++ b/pkg/monitoring/module.go
@@ -1,15 +1,40 @@
 package monitoring
 
+import (
+	"time"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/common"
+)
+
 type Alert string
 type Warning string
 
 type Module interface {
+	GetDescription() string
 	IsEnabled() bool
-	Run() error
-	GetName() string
-	GetExecutedCommand() string
-	GetAlerts() []Alert
-	GetWarnings() []Warning
-	GetMessage() string
-	GetMeasurements() map[string]interface{}
+	Run() ([]*ModuleReport, error)
+}
+
+// ModuleReport provides the results of Module run
+// Do not use the struct directly, use NewReport() to initialize it
+type ModuleReport struct {
+	Name            string                 `json:"name"`
+	Timestamp       common.Timestamp       `json:"timestamp"`
+	ExecutedCommand string                 `json:"command executed"`
+	Alerts          []Alert                `json:"alerts"`
+	Warnings        []Warning              `json:"warnings"`
+	Message         string                 `json:"message,omitempty"`
+	Measurements    map[string]interface{} `json:"measurements,omitempty"`
+}
+
+func NewReport(name string, t time.Time, cmd string) ModuleReport {
+	return ModuleReport{
+		Name:            name,
+		Timestamp:       common.Timestamp(t),
+		ExecutedCommand: cmd,
+		Alerts:          make([]Alert, 0),
+		Warnings:        make([]Warning, 0),
+		Message:         "",
+		Measurements:    nil,
+	}
 }

--- a/pkg/monitoring/storcli/parser_test.go
+++ b/pkg/monitoring/storcli/parser_test.go
@@ -8,19 +8,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func helperLoadTestData(t *testing.T, fileName string) []byte {
+func helperLoadAndParseTestData(t *testing.T, fileName string) *controllersResult {
 	path := filepath.Join("testdata", fileName)
-	result, err := ioutil.ReadFile(path)
+	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
+	result, err := tryParseCmdOutput(&b)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result.Controllers)
+
 	return result
 }
 
 func TestTryParseCmdOutput(t *testing.T) {
 	t.Run("all-good-output", func(t *testing.T) {
-		output := helperLoadTestData(t, "output_allgood.json")
-		measurements, alerts, warnings, err := tryParseCmdOutput(&output)
+		output := helperLoadAndParseTestData(t, "output_allgood.json")
+		measurements, alerts, warnings, err := getReportData(&output.Controllers[0].ResponseData)
 		assert.NoError(t, err)
 		assert.Empty(t, alerts)
 		assert.Empty(t, warnings)
@@ -28,8 +32,8 @@ func TestTryParseCmdOutput(t *testing.T) {
 	})
 
 	t.Run("all-good-output-ubuntu", func(t *testing.T) {
-		output := helperLoadTestData(t, "output_allgood_ubuntu.json")
-		measurements, alerts, warnings, err := tryParseCmdOutput(&output)
+		output := helperLoadAndParseTestData(t, "output_allgood_ubuntu.json")
+		measurements, alerts, warnings, err := getReportData(&output.Controllers[0].ResponseData)
 		assert.NoError(t, err)
 		assert.Empty(t, alerts)
 		assert.Empty(t, warnings)
@@ -37,8 +41,8 @@ func TestTryParseCmdOutput(t *testing.T) {
 	})
 
 	t.Run("non-optimal-output", func(t *testing.T) {
-		output := helperLoadTestData(t, "output_nonoptimal.json")
-		measurements, alerts, warnings, err := tryParseCmdOutput(&output)
+		output := helperLoadAndParseTestData(t, "output_nonoptimal.json")
+		measurements, alerts, warnings, err := getReportData(&output.Controllers[0].ResponseData)
 		assert.NoError(t, err)
 		assert.Empty(t, warnings)
 		assert.NotNil(t, measurements["Status"])
@@ -46,8 +50,8 @@ func TestTryParseCmdOutput(t *testing.T) {
 	})
 
 	t.Run("virtual-drive-bad-output", func(t *testing.T) {
-		output := helperLoadTestData(t, "output_vdbad.json")
-		measurements, alerts, warnings, err := tryParseCmdOutput(&output)
+		output := helperLoadAndParseTestData(t, "output_vdbad.json")
+		measurements, alerts, warnings, err := getReportData(&output.Controllers[0].ResponseData)
 		assert.NoError(t, err)
 		assert.Empty(t, warnings)
 		assert.NotNil(t, measurements["Status"])
@@ -55,8 +59,8 @@ func TestTryParseCmdOutput(t *testing.T) {
 	})
 
 	t.Run("hard-drive-bad-output", func(t *testing.T) {
-		output := helperLoadTestData(t, "output_hdbad.json")
-		measurements, alerts, warnings, err := tryParseCmdOutput(&output)
+		output := helperLoadAndParseTestData(t, "output_hdbad.json")
+		measurements, alerts, warnings, err := getReportData(&output.Controllers[0].ResponseData)
 		assert.NoError(t, err)
 		assert.Empty(t, alerts)
 		assert.NotEmpty(t, warnings)

--- a/pkg/monitoring/storcli/storcli_notwindows.go
+++ b/pkg/monitoring/storcli/storcli_notwindows.go
@@ -2,8 +2,6 @@
 
 package storcli
 
-import "fmt"
-
 func (s *StorCLI) getCommandLine() []string {
-	return []string{"sudo", s.binaryPath, fmt.Sprintf("/c%d", s.controller), "show", "all", "J"}
+	return []string{"sudo", s.binaryPath, "/call", "show", "all", "J"}
 }

--- a/pkg/monitoring/storcli/storcli_windows.go
+++ b/pkg/monitoring/storcli/storcli_windows.go
@@ -2,8 +2,6 @@
 
 package storcli
 
-import "fmt"
-
 func (s *StorCLI) getCommandLine() []string {
-	return []string{s.binaryPath, fmt.Sprintf("/c%d", s.controller), "show", "all", "J"}
+	return []string{s.binaryPath, "/call", "show", "all", "J"}
 }


### PR DESCRIPTION
- new 'timestamp' field: the time of last check
- virtual drive names now extracted from info to improve error messages
- new fields added to report: VDs status and the number of physical drives
- modules system reworked to support multiple reports per module. The storcli command execution status is always added to result object

DEV-1247