### PR TITLE
Split large handler.go file

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/troian/toml"
@@ -226,10 +225,6 @@ func defaultMinValuableConfig() *MinValuableConfig {
 		LogLevel: LogLevelError,
 		IOMode:   IOModeHTTP,
 	}
-}
-
-func secToDuration(secs float64) time.Duration {
-	return time.Duration(int64(float64(time.Second) * secs))
 }
 
 func (mvc *MinValuableConfig) applyEnv(force bool) {

--- a/hub.go
+++ b/hub.go
@@ -1,0 +1,193 @@
+package cagent
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/common"
+)
+
+func (ca *Cagent) initHubClientOnce() {
+	ca.hubClientOnce.Do(func() {
+		transport := &http.Transport{
+			ResponseHeaderTimeout: 15 * time.Second,
+		}
+
+		rootCAs, err := common.CustomRootCertPool()
+		if err != nil {
+			if err != common.ErrorCustomRootCertPoolNotImplementedForOS {
+				logrus.Errorf("failed to add root certs: %s", err.Error())
+			}
+		} else if rootCAs != nil {
+			transport.TLSClientConfig = &tls.Config{
+				RootCAs: rootCAs,
+			}
+		}
+
+		if len(ca.Config.HubProxy) > 0 {
+			if !strings.HasPrefix(ca.Config.HubProxy, "http://") {
+				ca.Config.HubProxy = "http://" + ca.Config.HubProxy
+			}
+			proxyURL, err := url.Parse(ca.Config.HubProxy)
+			if err != nil {
+				logrus.WithFields(logrus.Fields{
+					"url": ca.Config.HubProxy,
+				}).Warningln("failed to parse hub_proxy URL")
+			} else {
+				if len(ca.Config.HubProxyUser) > 0 {
+					proxyURL.User = url.UserPassword(ca.Config.HubProxyUser, ca.Config.HubProxyPassword)
+				}
+				transport.Proxy = func(_ *http.Request) (*url.URL, error) {
+					return proxyURL, nil
+				}
+			}
+		}
+		ca.hubClient = &http.Client{
+			Timeout:   time.Duration(ca.Config.HubRequestTimeout) * time.Second,
+			Transport: transport,
+		}
+	})
+}
+
+// validateHubURL performs Hub URL validation, that reference field name as in source config.
+func (ca *Cagent) validateHubURL(fieldHubURL string) error {
+	if len(ca.Config.HubURL) == 0 {
+		return newEmptyFieldError(fieldHubURL)
+	} else if u, err := url.Parse(ca.Config.HubURL); err != nil {
+		err = errors.WithStack(err)
+		return newFieldError(fieldHubURL, err)
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		err := errors.Errorf("wrong scheme '%s', URL must start with http:// or https://", u.Scheme)
+		return newFieldError(fieldHubURL, err)
+	}
+	return nil
+}
+
+// CheckHubCredentials performs credentials check for a Hub config, returning errors that reference
+// field names as in source config. Since config may be filled from file or UI, the field names can be different.
+// Consider also localization of UI, we want to decouple credential checking logic from their actual view in UI.
+//
+// Examples:
+// * for TOML: CheckHubCredentials(ctx, "hub_url", "hub_user", "hub_password")
+// * for WinUI: CheckHubCredentials(ctx, "URL", "User", "Password")
+func (ca *Cagent) CheckHubCredentials(ctx context.Context, fieldHubURL, fieldHubUser, fieldHubPassword string) error {
+	ca.initHubClientOnce()
+	err := ca.validateHubURL(fieldHubURL)
+	if err != nil {
+		return err
+	}
+
+	req, _ := http.NewRequest("HEAD", ca.Config.HubURL, nil)
+	req.Header.Add("User-Agent", ca.userAgent())
+	if len(ca.Config.HubUser) > 0 {
+		req.SetBasicAuth(ca.Config.HubUser, ca.Config.HubPassword)
+	}
+
+	ctx, cancelFn := context.WithTimeout(ctx, time.Minute)
+	req = req.WithContext(ctx)
+	resp, err := ca.hubClient.Do(req)
+	cancelFn()
+	if err = ca.checkClientError(resp, err, fieldHubUser, fieldHubPassword); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (ca *Cagent) checkClientError(resp *http.Response, err error, fieldHubUser, fieldHubPassword string) error {
+	if err != nil {
+		if errors.Cause(err) == context.DeadlineExceeded {
+			err = errors.New("connection timeout, please check your proxy or firewall settings")
+			return err
+		}
+		return err
+	}
+
+	var responseBody string
+	responseBodyBytes, readBodyErr := ioutil.ReadAll(resp.Body)
+	if readBodyErr == nil {
+		responseBody = string(responseBodyBytes)
+	}
+
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		if len(ca.Config.HubUser) == 0 {
+			return newEmptyFieldError(fieldHubUser)
+		} else if len(ca.Config.HubPassword) == 0 {
+			return newEmptyFieldError(fieldHubPassword)
+		}
+		return errors.Errorf("unable to authorize with provided Hub credentials (HTTP %d). %s", resp.StatusCode, responseBody)
+	} else if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		return errors.Errorf("got unexpected response from server (HTTP %d). %s", resp.StatusCode, responseBody)
+	}
+	return nil
+}
+
+func newEmptyFieldError(name string) error {
+	err := errors.Errorf("unexpected empty field %s", name)
+	return errors.Wrap(err, "the field must be filled with details of your Cloudradar account")
+}
+
+func newFieldError(name string, err error) error {
+	return errors.Wrapf(err, "%s field verification failed", name)
+}
+
+func (ca *Cagent) PostResultToHub(ctx context.Context, result *Result) error {
+	ca.initHubClientOnce()
+	err := ca.validateHubURL("hub_url")
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		err = errors.Wrap(err, "failed to serialize result")
+		return err
+	}
+
+	var req *http.Request
+	if ca.Config.HubGzip {
+		buf := new(bytes.Buffer)
+		gzipped := gzip.NewWriter(buf)
+		if _, err := gzipped.Write(b); err != nil {
+			err = errors.Wrap(err, "failed to write into gzipped buffer")
+			return err
+		}
+		if err := gzipped.Close(); err != nil {
+			err = errors.Wrap(err, "failed to finalize gzipped buffer")
+			return err
+		}
+		req, err = http.NewRequest("POST", ca.Config.HubURL, buf)
+		if req != nil {
+			req.Header.Set("Content-Encoding", "gzip")
+		}
+	} else {
+		req, err = http.NewRequest("POST", ca.Config.HubURL, bytes.NewBuffer(b))
+	}
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("User-Agent", ca.userAgent())
+	if len(ca.Config.HubUser) > 0 {
+		req.SetBasicAuth(ca.Config.HubUser, ca.Config.HubPassword)
+	}
+	req = req.WithContext(ctx)
+	resp, err := ca.hubClient.Do(req)
+	if err = ca.checkClientError(resp, err, "hub_user", "hub_password"); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/smart.go
+++ b/smart.go
@@ -1,0 +1,30 @@
+package cagent
+
+import (
+	"strings"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/common"
+)
+
+func (ca *Cagent) getSMARTMeasurements() common.MeasurementsMap {
+	if ca.smart != nil {
+		res, errs := ca.smart.Parse()
+
+		if len(errs) > 0 {
+			var errStr []string
+			for _, e := range errs {
+				errStr = append(errStr, e.Error())
+			}
+
+			if res == nil {
+				res = make(common.MeasurementsMap)
+			}
+
+			res["messages"] = strings.Join(errStr, "; ")
+		}
+
+		return res
+	}
+
+	return nil
+}

--- a/vm.go
+++ b/vm.go
@@ -1,0 +1,34 @@
+package cagent
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/common"
+	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat"
+	"github.com/cloudradar-monitoring/cagent/pkg/monitoring/vmstat/types"
+)
+
+func (ca *Cagent) getVMStatMeasurements(f func(string, common.MeasurementsMap, error)) {
+	ca.vmstatLazyInit.Do(func() {
+		if err := vmstat.Init(); err != nil {
+			logrus.Error("vmstat: cannot instantiate virtual machines API: ", err.Error())
+			return
+		}
+
+		for _, name := range ca.Config.VirtualMachinesStat {
+			vm, err := vmstat.Acquire(name)
+			if err != nil {
+				if err != types.ErrNotAvailable {
+					logrus.Warnf("vmstat: Error while acquiring vm provider \"%s\": %s", name, err.Error())
+				}
+			} else {
+				ca.vmWatchers[name] = vm
+			}
+		}
+	})
+
+	for name, p := range ca.vmWatchers {
+		res, err := p.GetMeasurements()
+		f(name, res, err)
+	}
+}


### PR DESCRIPTION
Main motivation is to reduce the upcoming Pull Request with jobmon feature (DEV-1324). 
I need to implement some new behavior in handler.go (to call some cleanup function if measurements were succefully reported to Hub or output file).
I decided to make some refactoring in this file as it is too big.

Main changes:
- Hub-related functions have been moved to hub.go. In future we can decouple it from Cagent object and reuse in other places (like csender, or even frontman).
- SMART and VMs monitoring measurements collection moved to separate files similar to other measurements
- Functions in handler.go slightly reordered and access mode updated (public->private).
- collectMeasurements function implementation slightly simplified
- one function moved from config.go to handler.go as this is the only place where it's used

No new code or behavior added.