### PR TITLE
fix wrong csender binary on synology&win_x86

### DIFF
--- a/build-win.bat
+++ b/build-win.bat
@@ -6,7 +6,7 @@ CD %build_dir%
 
 
 COPY dist\cagent_386.exe cagent.exe
-COPY dist\cagent_386.exe csender.exe
+COPY dist\csender_386.exe csender.exe
 go-msi make --src pkg-scripts\msi-templates --msi dist/_cagent_32.msi --version %cagent_version% --arch 386
 DEL cagent.exe
 DEL csender.exe

--- a/synology-spk/create_spk.sh
+++ b/synology-spk/create_spk.sh
@@ -14,7 +14,7 @@ sed -i.bak "s/{PKG_ARCH}/noarch/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 
 cp -f ../dist/cagent_linux_${ARCH}/cagent 1_create_package/cagent
-cp -f ../dist/cagent_linux_${ARCH}/cagent 1_create_package/cagent
+cp -f ../dist/csender_linux_${ARCH}/csender 1_create_package/csender
 
 cd 1_create_package
 tar cvfz package.tgz *


### PR DESCRIPTION
embed the right csender binary in the synology (all archs) and win x86 releases