### PR TITLE
Add two handy Makefile scripts which can be useful during development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,17 @@ synology-spk:
 	github-release upload --user cloudradar-monitoring --repo cagent --tag ${CIRCLE_TAG} --name "cagent_${CIRCLE_TAG}_synology_amd64.spk" --file "${PROJECT_DIR}/dist/cagent_${CIRCLE_TAG}_synology_amd64.spk"
 	github-release upload --user cloudradar-monitoring --repo cagent --tag ${CIRCLE_TAG} --name "cagent_${CIRCLE_TAG}_synology_armv7.spk" --file "${PROJECT_DIR}/dist/cagent_${CIRCLE_TAG}_synology_armv7.spk"
 	github-release upload --user cloudradar-monitoring --repo cagent --tag ${CIRCLE_TAG} --name "cagent_${CIRCLE_TAG}_synology_arm64.spk" --file "${PROJECT_DIR}/dist/cagent_${CIRCLE_TAG}_synology_arm64.spk"
+
+docker-goreleaser:
+	docker run -it --rm --privileged \
+		-v ${PWD}:${PROJECT_DIR} \
+		-v $(go env GOCACHE):/root/.cache/go-build \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-w ${PROJECT_DIR} \
+		goreleaser/goreleaser:v0.111 --snapshot --rm-dist --skip-publish
+
+docker-golangci-lint:
+	docker run -it --rm \
+		-v ${PWD}:${PROJECT_DIR} \
+		-w ${PROJECT_DIR} \
+		golangci/golangci-lint:v1.17 golangci-lint -c .golangci.yml run


### PR DESCRIPTION
First one allows to run goreleaser of specified version via Docker (without publishing the release). It allows to check that all binaries compiled successfully before pushing changes to Git.

Second one allows to run golangci-lint (for the same reason).