### PR TITLE
proxydetect package for windows system proxy detection

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudradar-monitoring/cagent/pkg/proxydetect"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
+	"github.com/cloudradar-monitoring/cagent/pkg/proxydetect"
 )
 
 func (ca *Cagent) initHubClientOnce() {

--- a/hub.go
+++ b/hub.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudradar-monitoring/cagent/pkg/proxydetect"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -20,9 +21,9 @@ import (
 
 func (ca *Cagent) initHubClientOnce() {
 	ca.hubClientOnce.Do(func() {
-		transport := &http.Transport{
-			ResponseHeaderTimeout: 15 * time.Second,
-		}
+		// copy the default transport struct
+		transport := *(http.DefaultTransport.(*http.Transport))
+		transport.ResponseHeaderTimeout = 15 * time.Second
 
 		rootCAs, err := common.CustomRootCertPool()
 		if err != nil {
@@ -35,7 +36,11 @@ func (ca *Cagent) initHubClientOnce() {
 			}
 		}
 
+		transport.Proxy = proxydetect.GetProxyForRequest
+
 		if len(ca.Config.HubProxy) > 0 {
+			// in case we have proxy set in the config
+			// it will override the proxy from the system
 			if !strings.HasPrefix(ca.Config.HubProxy, "http://") {
 				ca.Config.HubProxy = "http://" + ca.Config.HubProxy
 			}
@@ -55,7 +60,7 @@ func (ca *Cagent) initHubClientOnce() {
 		}
 		ca.hubClient = &http.Client{
 			Timeout:   time.Duration(ca.Config.HubRequestTimeout) * time.Second,
-			Transport: transport,
+			Transport: &transport,
 		}
 	})
 }

--- a/hub.go
+++ b/hub.go
@@ -37,6 +37,7 @@ func (ca *Cagent) initHubClientOnce() {
 		}
 
 		transport.Proxy = proxydetect.GetProxyForRequest
+		proxydetect.UserAgent = ca.userAgent()
 
 		if len(ca.Config.HubProxy) > 0 {
 			// in case we have proxy set in the config

--- a/pkg/csender/hub.go
+++ b/pkg/csender/hub.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/cloudradar-monitoring/cagent/pkg/proxydetect"
 	"github.com/pkg/errors"
 
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
@@ -29,6 +30,8 @@ func (cs *Csender) httpClient() *http.Client {
 			RootCAs: rootCAs,
 		}
 	}
+
+	tr.Proxy = proxydetect.GetProxyForRequest
 
 	return &http.Client{
 		Timeout:   HubTimeout,

--- a/pkg/csender/hub.go
+++ b/pkg/csender/hub.go
@@ -12,10 +12,10 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/cloudradar-monitoring/cagent/pkg/proxydetect"
 	"github.com/pkg/errors"
 
 	"github.com/cloudradar-monitoring/cagent/pkg/common"
+	"github.com/cloudradar-monitoring/cagent/pkg/proxydetect"
 )
 
 func (cs *Csender) httpClient() *http.Client {

--- a/pkg/csender/hub.go
+++ b/pkg/csender/hub.go
@@ -33,7 +33,7 @@ func (cs *Csender) httpClient() *http.Client {
 
 	tr.Proxy = proxydetect.GetProxyForRequest
 	proxydetect.UserAgent = cs.userAgent()
-	
+
 	return &http.Client{
 		Timeout:   HubTimeout,
 		Transport: &tr,

--- a/pkg/csender/hub.go
+++ b/pkg/csender/hub.go
@@ -32,7 +32,8 @@ func (cs *Csender) httpClient() *http.Client {
 	}
 
 	tr.Proxy = proxydetect.GetProxyForRequest
-
+	proxydetect.UserAgent = cs.userAgent()
+	
 	return &http.Client{
 		Timeout:   HubTimeout,
 		Transport: &tr,

--- a/pkg/proxydetect/proxydetect.go
+++ b/pkg/proxydetect/proxydetect.go
@@ -11,7 +11,7 @@ import (
 var ErrNotFound = fmt.Errorf("not found")
 var log = logrus.WithField("package", "proxydetect")
 
-func GetProxyForUrl(u *url.URL) (*url.URL, error) {
+func GetProxyForURL(u *url.URL) (*url.URL, error) {
 	// priority for the proxy set in the environment vars
 	req := http.Request{URL: u}
 	proxy, err := http.ProxyFromEnvironment(&req)
@@ -22,7 +22,7 @@ func GetProxyForUrl(u *url.URL) (*url.URL, error) {
 	}
 
 	// then fallback to the system-specific proxy detection(only windows is implemented right now)
-	return getProxyForUrl(u)
+	return getProxyForURL(u)
 }
 
 func GetProxyForRequest(r *http.Request) (*url.URL, error) {
@@ -37,7 +37,7 @@ func GetProxyForRequest(r *http.Request) (*url.URL, error) {
 		return nil, nil
 	}
 
-	proxy, err := GetProxyForUrl(r.URL)
+	proxy, err := GetProxyForURL(r.URL)
 	if err == ErrNotFound {
 		return nil, nil
 	}

--- a/pkg/proxydetect/proxydetect.go
+++ b/pkg/proxydetect/proxydetect.go
@@ -1,0 +1,46 @@
+package proxydetect
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/sirupsen/logrus"
+)
+
+var ErrNotFound = fmt.Errorf("not found")
+var log = logrus.WithField("package", "proxydetect")
+
+func GetProxyForUrl(u *url.URL) (*url.URL, error) {
+	// priority for the proxy set in the environment vars
+	req := http.Request{URL: u}
+	proxy, err := http.ProxyFromEnvironment(&req)
+	if err != nil {
+		return nil, err
+	} else if proxy != nil {
+		return proxy, nil
+	}
+
+	// then fallback to the system-specific proxy detection(only windows is implemented right now)
+	return getProxyForUrl(u)
+}
+
+func GetProxyForRequest(r *http.Request) (*url.URL, error) {
+	// to be compatible with http.Transport's Proxy field
+	//  we need to return nil, nil in case Proxy is not set
+
+	if r == nil {
+		return nil, nil
+	}
+
+	if r.URL == nil {
+		return nil, nil
+	}
+
+	proxy, err := GetProxyForUrl(r.URL)
+	if err == ErrNotFound {
+		return nil, nil
+	}
+
+	return proxy, err
+}

--- a/pkg/proxydetect/proxydetect.go
+++ b/pkg/proxydetect/proxydetect.go
@@ -10,6 +10,7 @@ import (
 
 var ErrNotFound = fmt.Errorf("not found")
 var log = logrus.WithField("package", "proxydetect")
+var UserAgent = "proxydetect" // used for autoconfig requests
 
 func GetProxyForURL(u *url.URL) (*url.URL, error) {
 	// priority for the proxy set in the environment vars

--- a/pkg/proxydetect/proxydetect_nonwindows.go
+++ b/pkg/proxydetect/proxydetect_nonwindows.go
@@ -6,6 +6,8 @@ import "net/url"
 
 // todo: darwin proxy detection
 
-func getProxyForUrl(u *url.URL) (*url.URL, error) {
+func getProxyForURL(u *url.URL) (*url.URL, error) {
+	// workaround non-used warning on windows
+	_ = log
 	return nil, ErrNotFound
 }

--- a/pkg/proxydetect/proxydetect_nonwindows.go
+++ b/pkg/proxydetect/proxydetect_nonwindows.go
@@ -4,10 +4,8 @@ package proxydetect
 
 import "net/url"
 
-// todo: darwin proxy detection
-
 func getProxyForURL(u *url.URL) (*url.URL, error) {
-	// workaround non-used warning on windows
+	// workaround non-used warning on unix
 	_ = log
 	return nil, ErrNotFound
 }

--- a/pkg/proxydetect/proxydetect_nonwindows.go
+++ b/pkg/proxydetect/proxydetect_nonwindows.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package proxydetect
+
+import "net/url"
+
+// todo: darwin proxy detection
+
+func getProxyForUrl(u *url.URL) (*url.URL, error) {
+	return nil, ErrNotFound
+}

--- a/pkg/proxydetect/proxydetect_windows.go
+++ b/pkg/proxydetect/proxydetect_windows.go
@@ -119,7 +119,7 @@ func getProxyForURL(u *url.URL) (proxy *url.URL, err error) {
 }
 
 func getProxyInfoForUrl(targetUrl *url.URL, autoProxyOptions *winapi.HttpAutoProxyOptions) (*winapi.HttpProxyInfo, error) {
-	userAgent, _ := windows.UTF16PtrFromString("cagent")
+	userAgent, _ := windows.UTF16PtrFromString(UserAgent)
 
 	h, err := winapi.HttpOpen(
 		userAgent,
@@ -154,7 +154,6 @@ func matchProxyForURLAndBypassList(targetUrl *url.URL, proxies []string, bypassL
 	// lets try to find the one that match the requested protocol, otherwise choose the one without specified protocol
 	for _, s := range proxies {
 		parts := strings.SplitN(s, "=", 2)
-		//
 		if len(parts) < 2 {
 			// assign a match, but keep looking in case we have a protocol specific match
 			proxyUrlStr = s

--- a/pkg/proxydetect/proxydetect_windows.go
+++ b/pkg/proxydetect/proxydetect_windows.go
@@ -1,0 +1,228 @@
+// +build windows
+
+package proxydetect
+
+import (
+	"net"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/cloudradar-monitoring/cagent/pkg/winapi"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	resolveTimeout = 5000
+	connectTimeout = 5000
+	sendTimeout    = 10000
+	receiveTimeout = 10000
+)
+
+func getProxyForUrl(u *url.URL) (proxy *url.URL, err error) {
+	ieProxy, err := winapi.HttpGetIEProxyConfigForCurrentUser()
+	if err != nil {
+		log.Errorf("HttpGetIEProxyConfigForCurrentUser error: %s", err.Error())
+	} else {
+		defer func() {
+			if err := ieProxy.Free(); err != nil {
+				log.Errorf("failed to free resources after winapi call: %s", err.Error())
+			}
+		}()
+
+		if ieProxy.FAutoDetect {
+			proxyInfo, err := getProxyInfoForUrl(u,
+				&winapi.HttpAutoProxyOptions{
+					DwFlags:                winapi.WINHTTP_AUTOPROXY_AUTO_DETECT,
+					DwAutoDetectFlags:      winapi.WINHTTP_AUTO_DETECT_TYPE_DHCP | winapi.WINHTTP_AUTO_DETECT_TYPE_DNS_A,
+					FAutoLogonIfChallenged: true,
+				})
+			if err == nil {
+				defer func() {
+					if err := proxyInfo.Free(); err != nil {
+						log.Errorf("WINHTTP_AUTOPROXY_AUTO_DETECT failed to free resources: %s", err.Error())
+					}
+				}()
+
+				proxy, err = matchProxyForURLAndBypassList(
+					u,
+					strings.Split(proxyInfo.LpszProxy.String(), ";"),
+					strings.Split(proxyInfo.LpszProxyBypass.String(), ";"),
+				)
+				if err == nil {
+					return proxy, nil
+				}
+			}
+			if err != ErrNotFound {
+				log.Errorf("WINHTTP_AUTOPROXY_AUTO_DETECT got error: %s", err.Error())
+			}
+		}
+
+		if ieProxy.LpszAutoConfigUrl.String() != "" {
+			proxyInfo, err := getProxyInfoForUrl(u,
+				&winapi.HttpAutoProxyOptions{
+					DwFlags:                winapi.WINHTTP_AUTOPROXY_CONFIG_URL,
+					LpszAutoConfigUrl:      ieProxy.LpszAutoConfigUrl,
+					FAutoLogonIfChallenged: true,
+				})
+			if err == nil {
+				defer func() {
+					if err := proxyInfo.Free(); err != nil {
+						log.Errorf("WINHTTP_AUTOPROXY_CONFIG_URL failed to free resources: %s", err.Error())
+					}
+				}()
+				proxy, err = matchProxyForURLAndBypassList(
+					u,
+					strings.Split(proxyInfo.LpszProxy.String(), ";"),
+					strings.Split(proxyInfo.LpszProxyBypass.String(), ";"),
+				)
+				if err == nil {
+					return proxy, nil
+				}
+			}
+
+			if err != ErrNotFound {
+				log.Errorf("WINHTTP_AUTOPROXY_CONFIG_URL got error: %s", err.Error())
+			}
+		}
+
+		proxy, err = matchProxyForURLAndBypassList(
+			u,
+			strings.Split(ieProxy.LpszProxy.String(), ";"),
+			strings.Split(ieProxy.LpszProxyBypass.String(), ";"),
+		)
+		if err == nil {
+			return proxy, nil
+		} else if err != ErrNotFound {
+			log.Errorf("WINHTTP_CURRENT_USER_IE_PROXY_CONFIG named proxy got error: %s", err.Error())
+		}
+	}
+
+	proxyInfo, err := winapi.HttpGetDefaultProxyConfiguration()
+	if err == nil {
+		defer func() {
+			if err := proxyInfo.Free(); err != nil {
+				log.Errorf("HttpGetDefaultProxyConfiguration failed to free resources: %s", err.Error())
+			}
+		}()
+
+		return matchProxyForURLAndBypassList(
+			u,
+			strings.Split(proxyInfo.LpszProxy.String(), ";"),
+			strings.Split(proxyInfo.LpszProxyBypass.String(), ";"),
+		)
+	} else if err != ErrNotFound {
+		log.Errorf("WinHttpGetDefaultProxyConfiguration got error: %s", err.Error())
+	}
+
+	return nil, ErrNotFound
+}
+
+func getProxyInfoForUrl(targetUrl *url.URL, autoProxyOptions *winapi.HttpAutoProxyOptions) (*winapi.HttpProxyInfo, error) {
+	userAgent, _ := windows.UTF16PtrFromString("cagent")
+
+	h, err := winapi.HttpOpen(
+		userAgent,
+		winapi.WINHTTP_ACCESS_TYPE_NO_PROXY,
+		nil,
+		nil,
+		0)
+	if err != nil {
+		return nil, err
+	}
+	defer winapi.HttpCloseHandle(h)
+
+	err = winapi.SetTimeouts(h, resolveTimeout, connectTimeout, sendTimeout, receiveTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyInfo, err := winapi.HttpGetProxyForUrl(h, targetUrl.String(), autoProxyOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return proxyInfo, nil
+}
+
+func matchProxyForURLAndBypassList(targetUrl *url.URL, proxies []string, bypassList []string) (*url.URL, error) {
+	var proxyUrlStr string
+	// lpszProxy can contains multiple proxies for different protocols
+	// "10.0.0.1" or
+	// "http=10.0.0.1;socks=10.0.0.2"
+
+	// lets try to find the one that match the requested protocol, otherwise choose the one without specified protocol
+	for _, s := range proxies {
+		parts := strings.SplitN(s, "=", 2)
+		//
+		if len(parts) < 2 {
+			// assign a match, but keep looking in case we have a protocol specific match
+			proxyUrlStr = s
+		} else if strings.EqualFold(strings.TrimSpace(parts[0]), targetUrl.Scheme) {
+			// note that unlike UNIX, HTTP proxy will not be chosen for HTTPS requests
+			proxyUrlStr = targetUrl.Scheme + "://" + parts[1]
+			break
+		} else if strings.EqualFold(strings.TrimSpace(parts[0]), "socks") {
+			// SOCKS is universal protocol and can handle HTTP, HTTPS, FTP and others underneath
+			// golang only supports SOCKS version 5, so assume that socks version is 5
+			proxyUrlStr = "socks5://" + parts[1]
+		}
+	}
+
+	if proxyUrlStr == "" {
+		return nil, ErrNotFound
+	}
+
+	if !strings.HasPrefix(proxyUrlStr, "//") && !strings.Contains(proxyUrlStr, "://") {
+		proxyUrlStr = "//" + proxyUrlStr
+	}
+
+	proxyUrl, err := url.Parse(proxyUrlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	if isUrlBypassesProxy(targetUrl, bypassList) {
+		return nil, ErrNotFound
+	}
+
+	return proxyUrl, nil
+}
+
+func isUrlBypassesProxy(targetUrl *url.URL, bypassList []string) bool {
+	targetHost := targetUrl.Hostname()
+	for _, bypass := range bypassList {
+		bypass = strings.TrimSpace(bypass)
+		if bypass == "" {
+			continue
+		} else if bypass == "<local>" {
+			// local used to bypass for all loopback addresses
+			addr, err := net.LookupIP(targetUrl.Hostname())
+			if err == nil && len(addr) > 0 && addr[0].IsLoopback() {
+				return true
+			}
+			continue
+		}
+		// use bypass as an exact pattern
+		if shouldBypass, err := filepath.Match(bypass, targetHost); err != nil {
+			return false
+		} else if shouldBypass {
+			return true
+		}
+
+		// add "*" to match subdomains (domain.com -> *.domain.com)
+		if !strings.HasPrefix(bypass, "*") {
+			if !strings.HasPrefix(bypass, ".") {
+				bypass = "." + bypass
+			}
+			bypass = "*" + bypass
+		}
+
+		if shouldBypass, err := filepath.Match(bypass, targetHost); err != nil {
+			return false
+		} else if shouldBypass {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/proxydetect/proxydetect_windows.go
+++ b/pkg/proxydetect/proxydetect_windows.go
@@ -19,7 +19,7 @@ const (
 	receiveTimeout = 10000
 )
 
-func getProxyForUrl(u *url.URL) (proxy *url.URL, err error) {
+func getProxyForURL(u *url.URL) (proxy *url.URL, err error) {
 	ieProxy, err := winapi.HttpGetIEProxyConfigForCurrentUser()
 	if err != nil {
 		log.Errorf("HttpGetIEProxyConfigForCurrentUser error: %s", err.Error())

--- a/pkg/winapi/types.go
+++ b/pkg/winapi/types.go
@@ -198,11 +198,11 @@ type HInternet uintptr
 
 // Wrap it to provide useful String() method
 // syscall sets the inline struct's field as it was same-level field
-type Lpwstr struct {
+type LPWSTR struct {
 	Value *uint16
 }
 
-func (l Lpwstr) Set(s string) error {
+func (l LPWSTR) Set(s string) error {
 	if s == "" {
 		return nil
 	}
@@ -216,21 +216,21 @@ func (l Lpwstr) Set(s string) error {
 	return nil
 }
 
-func (l Lpwstr) UTF16Ptr() *uint16 {
+func (l LPWSTR) UTF16Ptr() *uint16 {
 	return l.Value
 }
 
-func (l Lpwstr) String() string {
+func (l LPWSTR) String() string {
 	return win.UTF16PtrToString(l.Value)
 }
 
-func (l Lpwstr) Free() error {
+func (l LPWSTR) Free() error {
 	return GlobalFree(l.Value)
 }
 
-type Lpwstrs []Lpwstr
+type LPWSTRs []LPWSTR
 
-func (strs Lpwstrs) Free() error {
+func (strs LPWSTRs) Free() error {
 	var firstErr error
 	for _, lpwstr := range strs {
 		err := lpwstr.Free()
@@ -247,7 +247,7 @@ func (strs Lpwstrs) Free() error {
 type HttpAutoProxyOptions struct {
 	DwFlags                uint32  // DWORD
 	DwAutoDetectFlags      uint32  // DWORD
-	LpszAutoConfigUrl      Lpwstr  // LPCWSTR (same as LPWSTR, but const)
+	LpszAutoConfigUrl      LPWSTR  // LPCWSTR (same as LPWSTR, but const)
 	lpvReserved            uintptr // LPVOID
 	dwReserved             uint32  // DWORD
 	FAutoLogonIfChallenged bool    // BOOL
@@ -261,23 +261,23 @@ func (c HttpAutoProxyOptions) Free() error {
 // https://docs.microsoft.com/en-us/windows/win32/api/winhttp/ns-winhttp-winhttp_proxy_info
 type HttpProxyInfo struct {
 	DwAccessType    uint32 // DWORD
-	LpszProxy       Lpwstr // LPWSTR
-	LpszProxyBypass Lpwstr // LPWSTR
+	LpszProxy       LPWSTR // LPWSTR
+	LpszProxyBypass LPWSTR // LPWSTR
 }
 
 func (c HttpProxyInfo) Free() error {
-	return Lpwstrs([]Lpwstr{c.LpszProxy, c.LpszProxyBypass}).Free()
+	return LPWSTRs([]LPWSTR{c.LpszProxy, c.LpszProxyBypass}).Free()
 }
 
 // WINHTTP_CURRENT_USER_IE_PROXY_CONFIG
 // https://docs.microsoft.com/en-us/windows/win32/api/winhttp/ns-winhttp-winhttp_connection_info
 type HttpCurrentUserIEProxyConfig struct {
 	FAutoDetect       bool   // BOOL
-	LpszAutoConfigUrl Lpwstr // LPWSTR
-	LpszProxy         Lpwstr // LPWSTR
-	LpszProxyBypass   Lpwstr // LPWSTR
+	LpszAutoConfigUrl LPWSTR // LPWSTR
+	LpszProxy         LPWSTR // LPWSTR
+	LpszProxyBypass   LPWSTR // LPWSTR
 }
 
 func (c HttpCurrentUserIEProxyConfig) Free() error {
-	return Lpwstrs([]Lpwstr{c.LpszAutoConfigUrl, c.LpszProxy, c.LpszProxyBypass}).Free()
+	return LPWSTRs([]LPWSTR{c.LpszAutoConfigUrl, c.LpszProxy, c.LpszProxyBypass}).Free()
 }

--- a/pkg/winapi/types.go
+++ b/pkg/winapi/types.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"unicode/utf16"
 	"unsafe"
+
+	"github.com/lxn/win"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -189,4 +192,92 @@ type DiskPerformance struct {
 	QueryTime           int64
 	StorageDeviceNumber uint32
 	StorageManagerName  [8]uint16
+}
+
+type HInternet uintptr
+
+// Wrap it to provide useful String() method
+// syscall sets the inline struct's field as it was same-level field
+type Lpwstr struct {
+	Value *uint16
+}
+
+func (l Lpwstr) Set(s string) error {
+	if s == "" {
+		return nil
+	}
+
+	r, err := windows.UTF16PtrFromString(s)
+	if err != nil {
+		return err
+	}
+
+	l.Value = r
+	return nil
+}
+
+func (l Lpwstr) UTF16Ptr() *uint16 {
+	return l.Value
+}
+
+func (l Lpwstr) String() string {
+	return win.UTF16PtrToString(l.Value)
+}
+
+func (l Lpwstr) Free() error {
+	return GlobalFree(l.Value)
+}
+
+type Lpwstrs []Lpwstr
+
+func (strs Lpwstrs) Free() error {
+	var firstErr error
+	for _, lpwstr := range strs {
+		err := lpwstr.Free()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+// WINHTTP_AUTOPROXY_OPTIONS
+// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/ns-winhttp-winhttp_autoproxy_options#syntax
+type HttpAutoProxyOptions struct {
+	DwFlags                uint32  // DWORD
+	DwAutoDetectFlags      uint32  // DWORD
+	LpszAutoConfigUrl      Lpwstr  // LPCWSTR (same as LPWSTR, but const)
+	lpvReserved            uintptr // LPVOID
+	dwReserved             uint32  // DWORD
+	FAutoLogonIfChallenged bool    // BOOL
+}
+
+func (c HttpAutoProxyOptions) Free() error {
+	return c.LpszAutoConfigUrl.Free()
+}
+
+// WINHTTP_PROXY_INFO
+// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/ns-winhttp-winhttp_proxy_info
+type HttpProxyInfo struct {
+	DwAccessType    uint32 // DWORD
+	LpszProxy       Lpwstr // LPWSTR
+	LpszProxyBypass Lpwstr // LPWSTR
+}
+
+func (c HttpProxyInfo) Free() error {
+	return Lpwstrs([]Lpwstr{c.LpszProxy, c.LpszProxyBypass}).Free()
+}
+
+// WINHTTP_CURRENT_USER_IE_PROXY_CONFIG
+// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/ns-winhttp-winhttp_connection_info
+type HttpCurrentUserIEProxyConfig struct {
+	FAutoDetect       bool   // BOOL
+	LpszAutoConfigUrl Lpwstr // LPWSTR
+	LpszProxy         Lpwstr // LPWSTR
+	LpszProxyBypass   Lpwstr // LPWSTR
+}
+
+func (c HttpCurrentUserIEProxyConfig) Free() error {
+	return Lpwstrs([]Lpwstr{c.LpszAutoConfigUrl, c.LpszProxy, c.LpszProxyBypass}).Free()
 }

--- a/pkg/winapi/winapi.go
+++ b/pkg/winapi/winapi.go
@@ -8,8 +8,27 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logrus.WithField("package", "winapi")
+var (
+	log = logrus.WithField("package", "winapi")
+
+	procGlobalFree = kernel32DLL.NewProc("GlobalFree")
+)
 
 func add(p unsafe.Pointer, x uintptr) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(p) + x)
+}
+
+func GlobalFree(mem *uint16) error {
+	if mem == nil {
+		return nil
+	}
+	if err := procGlobalFree.Find(); err != nil {
+		return err
+	}
+	r, _, err := procGlobalFree.Call(uintptr(unsafe.Pointer(mem)))
+	if r == 0 {
+		return nil
+	}
+
+	return err
 }

--- a/pkg/winapi/winhttp.go
+++ b/pkg/winapi/winhttp.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package winapi
 
 import (

--- a/pkg/winapi/winhttp.go
+++ b/pkg/winapi/winhttp.go
@@ -1,0 +1,122 @@
+package winapi
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// WINHTTP_AUTOPROXY_OPTIONS
+// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/ns-winhttp-winhttp_autoproxy_options
+const (
+	// Attempt to automatically discover the URL of the PAC file using both DHCP and DNS queries to the local network.
+	WINHTTP_AUTOPROXY_AUTO_DETECT = 0x00000001
+	// Download the PAC file from the URL specified by lpszAutoConfigUrl in the WINHTTP_AUTOPROXY_OPTIONS structure.
+	WINHTTP_AUTOPROXY_CONFIG_URL = 0x00000002
+	// Use DHCP to locate the proxy auto-configuration file.
+	WINHTTP_AUTO_DETECT_TYPE_DHCP = 0x00000001
+	// Use DNS to attempt to locate the proxy auto-configuration file at a well-known location on the domain of the local computer.
+	WINHTTP_AUTO_DETECT_TYPE_DNS_A = 0x00000002
+	// Resolves all host names directly without a proxy.
+	WINHTTP_ACCESS_TYPE_NO_PROXY = 0x00000001
+)
+
+var (
+	winhttpDLL                             = windows.NewLazySystemDLL("winhttp.dll")
+	procHttpOpen                           = winhttpDLL.NewProc("WinHttpOpen")
+	procHttpCloseHandle                    = winhttpDLL.NewProc("WinHttpCloseHandle")
+	procHttpSetTimeouts                    = winhttpDLL.NewProc("WinHttpSetTimeouts")
+	procHttpGetProxyForUrl                 = winhttpDLL.NewProc("WinHttpGetProxyForUrl")
+	procHttpGetIEProxyConfigForCurrentUser = winhttpDLL.NewProc("WinHttpGetIEProxyConfigForCurrentUser")
+	procHttpGetDefaultProxyConfiguration   = winhttpDLL.NewProc("WinHttpGetDefaultProxyConfiguration")
+)
+
+func HttpOpen(pszAgentW *uint16, dwAccessType uint32, pszProxyW *uint16, pszProxyBypassW *uint16, dwFlags uint32) (HInternet, error) {
+	if err := procHttpOpen.Find(); err != nil {
+		return 0, err
+	}
+	r, _, err := procHttpOpen.Call(
+		uintptr(unsafe.Pointer(pszAgentW)),
+		uintptr(dwAccessType),
+		uintptr(unsafe.Pointer(pszProxyW)),
+		uintptr(unsafe.Pointer(pszProxyBypassW)),
+		uintptr(dwFlags),
+	)
+	if r == 0 {
+		return 0, err
+	}
+	return HInternet(r), nil
+
+}
+
+func SetTimeouts(hInternet HInternet, resolveTimeout int, connectTimeout int, sendTimeout int, receiveTimeout int) error {
+	if err := procHttpSetTimeouts.Find(); err != nil {
+		return err
+	}
+	r, _, err := procHttpSetTimeouts.Call(
+		uintptr(hInternet),
+		uintptr(resolveTimeout),
+		uintptr(connectTimeout),
+		uintptr(sendTimeout),
+		uintptr(receiveTimeout))
+	if r == 1 {
+		return nil
+	}
+	return err
+}
+
+func HttpCloseHandle(hInternet HInternet) error {
+	if err := procHttpCloseHandle.Find(); err != nil {
+		return err
+	}
+	r, _, err := procHttpCloseHandle.Call(uintptr(hInternet))
+	if r == 1 {
+		return nil
+	}
+
+	return err
+}
+
+func HttpGetProxyForUrl(hInternet HInternet, targetUrl string, pAutoProxyOptions *HttpAutoProxyOptions) (*HttpProxyInfo, error) {
+	if err := procHttpGetProxyForUrl.Find(); err != nil {
+		return nil, err
+	}
+
+	targetUrlPtr, _ := windows.UTF16PtrFromString(targetUrl)
+	p := new(HttpProxyInfo)
+	r, _, err := procHttpGetProxyForUrl.Call(
+		uintptr(hInternet),
+		uintptr(unsafe.Pointer(targetUrlPtr)),
+		uintptr(unsafe.Pointer(pAutoProxyOptions)),
+		uintptr(unsafe.Pointer(p)))
+
+	if r == 1 {
+		return p, nil
+	}
+	return nil, err
+}
+
+func HttpGetDefaultProxyConfiguration() (*HttpProxyInfo, error) {
+	pInfo := new(HttpProxyInfo)
+	if err := procHttpGetDefaultProxyConfiguration.Find(); err != nil {
+		return nil, err
+	}
+	r, _, err := procHttpGetDefaultProxyConfiguration.Call(uintptr(unsafe.Pointer(pInfo)))
+	if r == 1 {
+		return pInfo, nil
+	}
+	return nil, err
+}
+
+func HttpGetIEProxyConfigForCurrentUser() (*HttpCurrentUserIEProxyConfig, error) {
+	if err := procHttpGetIEProxyConfigForCurrentUser.Find(); err != nil {
+		return nil, err
+	}
+	p := new(HttpCurrentUserIEProxyConfig)
+	r, _, err := procHttpGetIEProxyConfigForCurrentUser.Call(uintptr(unsafe.Pointer(p)))
+	if r == 1 {
+		return p, nil
+	}
+
+	return nil, err
+}


### PR DESCRIPTION
Here is a list of priority when getting proxy on Windows(first non-error non-nil is chosen):
- hub_proxy from config
- HTTP_PROXY, HTTPS_PROXY and NO_PROXY (and lowercase variants) from env vars
- In case Autodetect is enabled in the Internet Options, use [Proxy Autodetect via DHCP and DNS_A](https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpdetectautoproxyconfigurl#parameters) to get the proxy, then apply the bypass list
- In case Automatic config URL is specified in the Internet Options use it to get the proxy, then apply the bypass list
- Use manual proxy if specified in the Internet Options, then apply the bypass list
- Use the default WinHTTP proxy configuration from the registry. [Usually set with proxycfg.exe](https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpgetdefaultproxyconfiguration#remarks)

In case it has got multiple proxies for different protocol
- try to find the one that matches the URL schema(e.g. `https`)
- in case it doesn't find the proxy for the URL schema, retreive the universal `socks` or the one without protocol specified