### PR TITLE
Add the monitoring of 'security' updates where possible

### DIFF
--- a/pkg-scripts/cagent-dnf
+++ b/pkg-scripts/cagent-dnf
@@ -1,1 +1,1 @@
-cagent ALL= NOPASSWD: /usr/bin/dnf -q check-update
+cagent ALL= NOPASSWD: /usr/bin/dnf -q check-update, /usr/bin/dnf -q list-security

--- a/pkg-scripts/cagent-yum
+++ b/pkg-scripts/cagent-yum
@@ -1,1 +1,1 @@
-cagent ALL= NOPASSWD: /usr/bin/yum -q check-update
+cagent ALL= NOPASSWD: /usr/bin/yum -q check-update, /usr/bin/yum -q list-security

--- a/pkg/monitoring/updates/pkgmgr.go
+++ b/pkg/monitoring/updates/pkgmgr.go
@@ -11,7 +11,7 @@ const (
 type pkgMgr interface {
 	GetBinaryPath() string
 	FetchUpdates(timeout time.Duration) error
-	GetAvailableUpdatesCount() (int, error)
+	GetAvailableUpdatesCount() (int, *int, error)
 }
 
 func newPkgMgr(pkgMgrName string) pkgMgr {

--- a/pkg/monitoring/updates/updates.go
+++ b/pkg/monitoring/updates/updates.go
@@ -87,13 +87,14 @@ func (w *Watcher) tryFetchAndParseUpdatesInfo() (map[string]interface{}, error) 
 		return nil, err
 	}
 
-	available, err := mgr.GetAvailableUpdatesCount()
+	totalUpgrades, securityUpgrades, err := mgr.GetAvailableUpdatesCount()
 	if err != nil {
 		return nil, err
 	}
 
 	results := map[string]interface{}{
-		"updates_available": available,
+		"updates_available":          totalUpgrades,
+		"security_updates_available": securityUpgrades,
 	}
 	return results, nil
 }


### PR DESCRIPTION
DEV-1333

Debian-based systems will call apt-check if it's available. (Installed by default starting from Ubuntu 12).
CentOS will call yum security plugin if installed. (Installed by default starting from CentOS 7.)

Null field supplied in result object otherwise.