### PR TITLE
add windows_update to config and provide more clear error

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,7 +94,8 @@ type Config struct {
 
 	SystemFields []string `toml:"system_fields" comment:"default ['uname','os_kernel','os_family','os_arch','cpu_model','fqdn','memory_total_B']"`
 
-	WindowsUpdatesWatcherInterval int `toml:"windows_updates_watcher_interval" comment:"default 3600"`
+	WindowsUpdates                bool `toml:"windows_updates" comment:"default true"`
+	WindowsUpdatesWatcherInterval int  `toml:"windows_updates_watcher_interval" comment:"default 3600"`
 
 	VirtualMachinesStat []string `toml:"virtual_machines_stat" comment:"default ['hyper-v'], available options 'hyper-v'"`
 
@@ -245,6 +246,7 @@ func NewConfig() *Config {
 
 	switch runtime.GOOS {
 	case "windows":
+		cfg.WindowsUpdates = true
 		cfg.WindowsUpdatesWatcherInterval = 3600
 		cfg.NetInterfaceExcludeRegex = append(cfg.NetInterfaceExcludeRegex, "Pseudo-Interface")
 		cfg.CPULoadDataGather = []string{}

--- a/handler.go
+++ b/handler.go
@@ -135,10 +135,13 @@ func (ca *Cagent) collectMeasurements(fullMode bool) (common.MeasurementsMap, Cl
 			}
 		})
 
-		if runtime.GOOS == "windows" {
-			wu, err := ca.WindowsUpdatesWatcher().WindowsUpdates()
-			errCollector.Add(err)
-			measurements = measurements.AddWithPrefix("windows_update.", wu)
+		if runtime.GOOS == "windows" && ca.Config.WindowsUpdates && ca.Config.WindowsUpdatesWatcherInterval > 0 {
+			watcher := ca.WindowsUpdatesWatcher()
+			if watcher != nil {
+				wu, err := watcher.WindowsUpdates()
+				errCollector.Add(err)
+				measurements = measurements.AddWithPrefix("windows_update.", wu)
+			}
 		}
 
 		if cfg.LinuxUpdatesChecks.Enabled {


### PR DESCRIPTION
DEV-1390
- add `windows_update` option to the config (`true` by default)
- disable windows update watcher if `windows_updates_watcher_interval`<=0
- pass system errors from windows update query to the measurements
- add a more clear user-facing error in case "Windows Updates" is disabled on the host