### PR TITLE
win updates: use relative time

### DIFF
--- a/pkg/monitoring/updates/updates.go
+++ b/pkg/monitoring/updates/updates.go
@@ -16,7 +16,6 @@ type Watcher struct {
 	fetchTimeout    time.Duration
 	checkInterval   time.Duration
 	lastFetchedInfo map[string]interface{}
-	lastFetchedTime time.Time
 
 	lastError     error
 	interruptChan chan struct{}
@@ -52,7 +51,6 @@ func (w *Watcher) GetSystemUpdatesInfo() (map[string]interface{}, error) {
 func (w *Watcher) Run() {
 	for {
 		w.lastFetchedInfo, w.lastError = w.tryFetchAndParseUpdatesInfo()
-		w.lastFetchedTime = time.Now()
 		select {
 		case <-w.interruptChan:
 			return


### PR DESCRIPTION
Instead of the Unix timestamp, it will be better to provide relative time in seconds.
`last_update_timestamp` -> `last_updates_installed_ago_sec`
Also added `last_query_age_sec`