### PR TITLE
Add more error handling code for debug purposes and enable windows update watcher

### DIFF
--- a/cmd/cagent/main.go
+++ b/cmd/cagent/main.go
@@ -150,6 +150,8 @@ func main() {
 
 	handleFlagOneRunOnlyMode(ca, *oneRunOnlyModePtr, output)
 
+	log.Errorf("cagent v%s starting...", cagent.Version)
+
 	// nothing resulted in os.Exit
 	// so lets use the default continuous run mode and wait for interrupt
 	// setup interrupt handler
@@ -570,6 +572,8 @@ func (sw *serviceWrapper) Start(s service.Service) error {
 	sw.InterruptChan = make(chan struct{})
 	sw.WG = sync.WaitGroup{}
 	sw.HeartbeatInterruptChan = make(chan struct{})
+
+	log.Errorf("cagent v%s starting in service mode...", cagent.Version)
 
 	sw.WG.Add(1)
 	go func() {

--- a/config.go
+++ b/config.go
@@ -251,7 +251,7 @@ func NewConfig() *Config {
 			SpoolDirPath: "/var/lib/cagent/jobmon",
 		},
 		SystemUpdatesChecks: UpdatesMonitoringConfig{
-			Enabled:       runtime.GOOS != "windows", // Temporarily disabled by default on Windows. will be fixed in next version.
+			Enabled:       true,
 			FetchTimeout:  30,
 			CheckInterval: 14400,
 		},

--- a/handler.go
+++ b/handler.go
@@ -44,6 +44,13 @@ func (c *cleanupCommand) Cleanup() error {
 }
 
 func (ca *Cagent) Run(outputFile *os.File, interrupt chan struct{}) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("Unexpected error occurred (main routine): %s", err)
+			panic(err)
+		}
+	}()
+
 	for {
 		err := ca.RunOnce(outputFile, ca.Config.OperationMode == OperationModeFull)
 		if err != nil {

--- a/pkg-scripts/msi-templates/product.wxs
+++ b/pkg-scripts/msi-templates/product.wxs
@@ -92,8 +92,8 @@
                                         RestartServiceDelayInSeconds="60"
                                         ResetPeriodInDays="0"
                                         FirstFailureActionType="restart"
-                                        SecondFailureActionType="none"
-                                        ThirdFailureActionType="none"
+                                        SecondFailureActionType="restart"
+                                        ThirdFailureActionType="restart"
                                     />
                                 </ServiceInstall>
                                 <ServiceControl Id="StartService" Name="Cagent" Stop="both" Start="install" Remove="uninstall" Wait="yes">

--- a/pkg/monitoring/top/top.go
+++ b/pkg/monitoring/top/top.go
@@ -83,6 +83,13 @@ func (t *Top) startMeasureProcessLoad(interval time.Duration) {
 	var len5 = 5 * 60 / int(interval.Seconds())
 	var len15 = 15 * 60 / int(interval.Seconds())
 
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("Unexpected error occurred (startMeasureProcessLoad): %s", err)
+			panic(err)
+		}
+	}()
+
 	for {
 		select {
 		case <-t.interruptChan:

--- a/pkg/monitoring/updates/updates.go
+++ b/pkg/monitoring/updates/updates.go
@@ -49,6 +49,13 @@ func (w *Watcher) GetSystemUpdatesInfo() (map[string]interface{}, error) {
 }
 
 func (w *Watcher) Run() {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("Unexpected error occurred (updates watcher): %s", err)
+			panic(err)
+		}
+	}()
+
 	for {
 		info, err := w.tryFetchAndParseUpdatesInfo()
 		if err != nil {


### PR DESCRIPTION
Add logging of runtime errors for two goroutines.
Enable Windows Update watcher by default.
Add logging of cagent service startup.
Update Windows service restart policy to "restart always"