### PR TITLE
Fix panic "too many callbacks" when running agent for a long time on Windows

### DIFF
--- a/pkg/monitoring/processes/processes_windows.go
+++ b/pkg/monitoring/processes/processes_windows.go
@@ -14,6 +14,11 @@ import (
 
 var monitoredProcessCache = make(map[uint32]*winapi.SystemProcessInformation)
 var lastProcessQueryTime time.Time
+var windowsEnumerator *winapi.WindowsEnumerator
+
+func init() {
+	windowsEnumerator = winapi.NewWindowsEnumerator()
+}
 
 func processes(systemMemorySize uint64) ([]*ProcStat, error) {
 	procByPid, threadsByProcPid, err := winapi.GetSystemProcessInformation(false)
@@ -31,7 +36,7 @@ func processes(systemMemorySize uint64) ([]*ProcStat, error) {
 	var updatedProcessCache = make(map[uint32]*winapi.SystemProcessInformation)
 	cmdLineRetrievalFailuresCount := 0
 	logicalCPUCount := uint8(runtime.NumCPU())
-	windowByProcessId, err := winapi.WindowByProcessId()
+	windowByProcessId, err := windowsEnumerator.Enumerate()
 	if err != nil {
 		log.Errorf("failed to list all windows by processId")
 	}

--- a/pkg/winapi/user32dll.go
+++ b/pkg/winapi/user32dll.go
@@ -14,6 +14,44 @@ var (
 	procIsHungAppWindow          = user32.MustFindProc("IsHungAppWindow")
 )
 
+
+type WindowsEnumerator struct {
+	currentList        *map[uint32]syscall.Handle
+	compiledCallbackFn uintptr
+}
+
+// NewWindowsEnumerator returns an object for enumerating window handles
+// it's important not to create too many enumerators as
+// there is a runtime limit of how many callback objects can be created
+func NewWindowsEnumerator() *WindowsEnumerator {
+	list := make(map[uint32]syscall.Handle)
+	we := WindowsEnumerator{
+		currentList: &list,
+	}
+	we.compiledCallbackFn = syscall.NewCallback(func(h syscall.Handle, p uintptr) uintptr {
+		var windowProcessId uint32
+		_, err := GetWindowThreadProcessId(h, &windowProcessId)
+		if err != nil {
+			// ignore the error
+			return 1 // continue enumeration
+		}
+		list[windowProcessId] = h
+
+		return 1 // continue enumeration
+	})
+	return &we
+}
+
+func (we *WindowsEnumerator) Enumerate() (map[uint32]syscall.Handle, error) {
+	*we.currentList = make(map[uint32]syscall.Handle)
+	err := EnumWindows(we.compiledCallbackFn, 0)
+	if err != nil {
+		return nil, err
+	}
+	return *(we.currentList), nil
+}
+
+
 func EnumWindows(enumFunc uintptr, lparam uintptr) (err error) {
 	r1, _, e1 := syscall.Syscall(procEnumWindows.Addr(), 2, uintptr(enumFunc), uintptr(lparam), 0)
 	if r1 == 0 {
@@ -37,29 +75,6 @@ func GetWindowThreadProcessId(hwnd syscall.Handle, str *uint32) (len int32, err 
 		}
 	}
 	return
-}
-
-func WindowByProcessId() (map[uint32]syscall.Handle, error) {
-	m := make(map[uint32]syscall.Handle)
-
-	cb := syscall.NewCallback(func(h syscall.Handle, p uintptr) uintptr {
-		var windowProcessId uint32
-		_, err := GetWindowThreadProcessId(h, &windowProcessId)
-		if err != nil {
-			// ignore the error
-			return 1 // continue enumeration
-		}
-		m[windowProcessId] = h
-
-		return 1 // continue enumeration
-	})
-
-	err := EnumWindows(cb, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	return m, nil
 }
 
 func IsHangWindow(hwnd syscall.Handle) (bool, error) {


### PR DESCRIPTION
DEV-1429

syscall.NewCallback() may be called only 2000 times in Go runtime.
Afterwards it throws a panic. The implementation updated to execute it only once.


```
fatal error: too many callback functions

goroutine 11 [running]:
runtime.throw(0xab4c6e, 0x1b)
    /usr/lib/go/src/runtime/panic.go:774 +0x79 fp=0xc00010f120 sp=0xc00010f0f0 pc=0x431209
syscall.compileCallback(0x9c2280, 0xc00050d690, 0x40db01, 0xa5b1e0)
    /usr/lib/go/src/runtime/syscall_windows.go:89 +0x2db fp=0xc00010f160 sp=0xc00010f120 pc=0x44bb2b
syscall.NewCallback(...)
    /usr/lib/go/src/syscall/syscall_windows.go:147
github.com/cloudradar-monitoring/cagent/pkg/winapi.WindowByProcessId(0xc0006deba0, 0x9e239f98f5c5, 0x1034360)
    /home/nikita/go/src/github.com/cloudradar-monitoring/cagent/pkg/winapi/user32dll.go:45 +0x85 fp=0xc00010f198 sp=0xc00010f160 pc=0x743265
github.com/cloudradar-monitoring/cagent/pkg/monitoring/processes.processes(0xfff78000, 0xc00050d2f0, 0x20, 0x0, 0x0, 0xc0006e8c20)
    /home/nikita/go/src/github.com/cloudradar-monitoring/cagent/pkg/monitoring/processes/processes_windows.go:34 +0x116 fp=0xc00010f4b8 sp=0xc00010f198 pc=0x7e2c76
...
```