### PR TITLE
Add "integration" test for cagent main function

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,39 @@
+package cagent
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func helperCreateCagent(t *testing.T) *Cagent {
+	t.Helper()
+
+	tmpFile, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+
+	tmpFilePath := tmpFile.Name()
+	defer os.Remove(tmpFilePath)
+
+	cfg, err := HandleAllConfigSetup(tmpFilePath)
+	assert.NoError(t, err)
+
+	ca, err := New(cfg, tmpFilePath)
+	assert.NoError(t, err)
+
+	return ca
+}
+
+func TestCagentCollectMeasurements(t *testing.T) {
+	ca := helperCreateCagent(t)
+	defer ca.Shutdown()
+
+	m, _ := ca.collectMeasurements(true)
+	errorMsg, ok := m["message"]
+	if !ok {
+		errorMsg = ""
+	}
+	assert.Equal(t, 1, m["cagent.success"], "msg %s", errorMsg)
+}

--- a/pkg/hwinfo/hwinfo_other.go
+++ b/pkg/hwinfo/hwinfo_other.go
@@ -92,7 +92,10 @@ func listPCIDevices() ([]*pciDeviceInfo, error) {
 		return nil, errors.Wrap(err, "could not capture stderr when retrieving PCI information using ghw")
 	}
 	if ghwErr != nil {
-		return nil, errors.Wrap(ghwErr, "there were error while retrieving PCI information using ghw")
+		// ignore "no such file or directory" error returned only when ghw can't find vendor DB file on a machine
+		if !strings.Contains(ghwErr.Error(), "open : no such file or directory") {
+			return nil, errors.Wrap(ghwErr, "there were error while retrieving PCI information using ghw")
+		}
 	}
 	if len(stderrOutput) > 0 {
 		// ghw only reports to stderr in case if system files are missing or there was failure while reading it


### PR DESCRIPTION
Test coverage increased from 16% to 35%


```
➜ go tool cover  -func=cover.out | grep total          
total:                                       (statements)                     16.1%
➜ go tool cover  -func=cover_new.out | grep total      
total:                                       (statements)                35.3%

```