### PR TITLE
Fix building releases when multiple tags pointing to the same commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 docker_job_setup: &docker_job
   docker:
-    - image: cloudradario/go-build:0.0.17
+    - image: cloudradario/go-build:0.0.18
   working_directory: /go/src/github.com/cloudradar-monitoring/cagent
 
 attach_workspace: &workspace
@@ -55,6 +55,7 @@ jobs:
         type: string
     environment:
       RELEASE_MODE: << parameters.release_mode >>
+      GORELEASER_CURRENT_TAG: ${CIRCLE_TAG}
     steps:
       - <<: *workspace
       - run:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -154,61 +154,62 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-nfpm:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-  maintainer: CloudRadar GmbH <ops@cloudradar.io>
+nfpms:
+  -
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    maintainer: CloudRadar GmbH <ops@cloudradar.io>
 
-  vendor: cloudradar GmbH
-  homepage: https://cloudradar.io
-  description: Monitoring agent to report CPU, disk, mem and net metrics
-  license: MIT
+    vendor: cloudradar GmbH
+    homepage: https://cloudradar.io
+    description: Monitoring agent to report CPU, disk, mem and net metrics
+    license: MIT
 
-  # Formats to be generated.
-  formats:
-    - deb
-    - rpm
+    # Formats to be generated.
+    formats:
+      - deb
+      - rpm
 
-  dependencies:
-    - sudo
+    dependencies:
+      - sudo
 
-  recommends:
-    - dmidecode
-    - usbutils
-    - ca-certificates
-    - dbus
+    recommends:
+      - dmidecode
+      - usbutils
+      - ca-certificates
+      - dbus
 
-  # Override default /usr/local/bin destination for binaries
-  bindir: /usr/bin
+    # Override default /usr/local/bin destination for binaries
+    bindir: /usr/bin
 
-  # Empty folders that should be created and managed by the packager implementation.
-  empty_folders:
-    - /var/log/cagent
-    - /var/lib/cagent/jobmon
-    - /etc/cagent
+    # Empty folders that should be created and managed by the packager implementation.
+    empty_folders:
+      - /var/log/cagent
+      - /var/lib/cagent/jobmon
+      - /etc/cagent
 
-  files:
-    "example.config.toml": "/etc/cagent/example.config.toml"
-    "cacert.pem": "/etc/cagent/cacert.pem"
-    "pkg-scripts/cagent-dmidecode": "/etc/sudoers.d/cagent-dmidecode"
-    "pkg-scripts/cagent-docker": "/etc/sudoers.d/cagent-docker"
-    "pkg-scripts/cagent-smartctl": "/etc/sudoers.d/cagent-smartctl"
+    files:
+      "example.config.toml": "/etc/cagent/example.config.toml"
+      "cacert.pem": "/etc/cagent/cacert.pem"
+      "pkg-scripts/cagent-dmidecode": "/etc/sudoers.d/cagent-dmidecode"
+      "pkg-scripts/cagent-docker": "/etc/sudoers.d/cagent-docker"
+      "pkg-scripts/cagent-smartctl": "/etc/sudoers.d/cagent-smartctl"
 
-  scripts:
-    preinstall: "pkg-scripts/preinstall.sh"
-    postinstall: "pkg-scripts/postinstall.sh"
-    preremove: "pkg-scripts/preremove.sh"
+    scripts:
+      preinstall: "pkg-scripts/preinstall.sh"
+      postinstall: "pkg-scripts/postinstall.sh"
+      preremove: "pkg-scripts/preremove.sh"
 
-  overrides:
-    deb:
-      files:
-        "pkg-scripts/cagent-apt-get": "/etc/sudoers.d/cagent-apt-get"
-    rpm:
-      files:
-        "pkg-scripts/cagent-yum": "/etc/sudoers.d/cagent-yum"
-        "pkg-scripts/cagent-dnf": "/etc/sudoers.d/cagent-dnf"
-      scripts:
-        postinstall: "pkg-scripts/postinstall-rpm.sh"
-        preremove: "pkg-scripts/preremove-rpm.sh"
+    overrides:
+      deb:
+        files:
+          "pkg-scripts/cagent-apt-get": "/etc/sudoers.d/cagent-apt-get"
+      rpm:
+        files:
+          "pkg-scripts/cagent-yum": "/etc/sudoers.d/cagent-yum"
+          "pkg-scripts/cagent-dnf": "/etc/sudoers.d/cagent-dnf"
+        scripts:
+          postinstall: "pkg-scripts/postinstall-rpm.sh"
+          preremove: "pkg-scripts/preremove-rpm.sh"
 
 release:
   github:

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ goreleaser-precheck:
 	@if [ -z ${PROPRIETARY_SELF_UPDATES_FEED_URL} ]; then echo "PROPRIETARY_SELF_UPDATES_FEED_URL is empty"; exit 1; fi
 
 goreleaser-rm-dist: goreleaser-precheck
-	SELF_UPDATES_FEED_URL=$(SELF_UPDATES_FEED_URL) PROPRIETARY_SELF_UPDATES_FEED_URL=$(PROPRIETARY_SELF_UPDATES_FEED_URL) goreleaser --rm-dist
+	GORELEASER_CURRENT_TAG=$(GORELEASER_CURRENT_TAG) SELF_UPDATES_FEED_URL=$(SELF_UPDATES_FEED_URL) PROPRIETARY_SELF_UPDATES_FEED_URL=$(PROPRIETARY_SELF_UPDATES_FEED_URL) goreleaser --rm-dist
 
 goreleaser-snapshot: goreleaser-precheck
-	SELF_UPDATES_FEED_URL=$(SELF_UPDATES_FEED_URL) PROPRIETARY_SELF_UPDATES_FEED_URL=$(PROPRIETARY_SELF_UPDATES_FEED_URL) goreleaser --snapshot --rm-dist
+	GORELEASER_CURRENT_TAG=$(GORELEASER_CURRENT_TAG) SELF_UPDATES_FEED_URL=$(SELF_UPDATES_FEED_URL) PROPRIETARY_SELF_UPDATES_FEED_URL=$(PROPRIETARY_SELF_UPDATES_FEED_URL) goreleaser --snapshot --rm-dist
 
 goimports:
 	goimports -l $$(find . -type f -name '*.go' -not -path "./vendor/*")
@@ -55,7 +55,7 @@ docker-goreleaser: goreleaser-precheck
 		-w ${PROJECT_DIR} \
 		-e SELF_UPDATES_FEED_URL=$(SELF_UPDATES_FEED_URL) \
 		-e PROPRIETARY_SELF_UPDATES_FEED_URL=$(SELF_UPDATES_FEED_URL) \
-		goreleaser/goreleaser:v0.111 --snapshot --rm-dist --skip-publish
+		goreleaser/goreleaser:v0.126 --snapshot --rm-dist --skip-publish
 
 docker-golangci-lint:
 	docker run -it --rm \


### PR DESCRIPTION
goreleaser uses "git describe" command to get release name. It always returns same tag even if there are multiple tags pointing to same commit.
Starting from v0.126 goreleaser supports overriding tag name using env variable: https://github.com/goreleaser/goreleaser/pull/1327