### PR TITLE
fix json encode error when sending to hub

### DIFF
--- a/pkg/monitoring/processes/processes_notwindows.go
+++ b/pkg/monitoring/processes/processes_notwindows.go
@@ -403,7 +403,10 @@ func gatherProcessResourceUsage(proc *process.Process, systemMemorySize uint64) 
 		log.WithError(err).Error("failed to get memory info")
 		return 0, 0, 0.0, 0.0
 	}
-	memUsagePercent := (float64(memoryInfo.RSS) / float64(systemMemorySize)) * 100
+	memUsagePercent := 0.0
+	if systemMemorySize > 0 {
+		memUsagePercent = (float64(memoryInfo.RSS) / float64(systemMemorySize)) * 100
+	}
 
 	// side effect: p.Percent() call update process internally
 	cpuUsagePercent, err := proc.Percent(time.Duration(0))


### PR DESCRIPTION
This PR fixes the case where the "proc.list" Measurement contains Inf or NaN values. This happens if cagent is configured with `mem_monitoring = false`

JSON marshal cannot encode Inf or NaN values and errors out trying to send to hub.


example input that cause the issue:
```
&processes.ProcStat{PID:17355, ParentPID:995, ProcessGID:979, Name:"sleep", Cmdline:"sleep 60", State:"sleeping", Container:"", CPUAverageUsagePercent:0, RSS:0xc9000, VMS:0x71c000, MemoryUsagePercent:+Inf},
&processes.ProcStat{PID:15071, ParentPID:2, ProcessGID:0, Name:"kworker/0:7-events", Cmdline:"", State:"idle", Container:"", CPUAverageUsagePercent:0, RSS:0x0, VMS:0x0, MemoryUsagePercent:NaN},
            
```

DEV-1581 follow-up