### PR TITLE
fix memUsagePercent calculation if cagent is configured with mem_monitoring = false for the windows path

### DIFF
--- a/pkg/monitoring/processes/processes_windows.go
+++ b/pkg/monitoring/processes/processes_windows.go
@@ -87,7 +87,11 @@ func processes(systemMemorySize uint64) ([]*ProcStat, error) {
 			}
 		}
 
-		memoryUsagePercent := (float64(proc.WorkingSetSize) / float64(systemMemorySize)) * 100
+		memoryUsagePercent := 0.0
+		if systemMemorySize > 0 {
+			memoryUsagePercent = (float64(proc.WorkingSetSize) / float64(systemMemorySize)) * 100
+		}
+
 		ps := &ProcStat{
 			PID:                    int(pid),
 			ParentPID:              int(proc.InheritedFromUniqueProcessID),


### PR DESCRIPTION
Same as https://github.com/cloudradar-monitoring/cagent/pull/269 but for the Windows code path.

DEV-1581