### PR TITLE
Log location for Unix is cagent.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Default locations:
 ## Logs location
 * Mac OS: `~/.cagent/cagent.log`
 * Windows: `./cagent.log`
-* UNIX: `/etc/cagent/cagent.conf`
+* UNIX: `/etc/cagent/cagent.log`
 
 ## Build binaries and deb/rpm packages
 – Install [goreleaser](https://goreleaser.com/introduction/)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Default locations:
 ## Logs location
 * Mac OS: `~/.cagent/cagent.log`
 * Windows: `./cagent.log`
-* UNIX: `/etc/cagent/cagent.log`
+* UNIX: `/var/log/cagent/cagent.log`
 
 ## Build binaries and deb/rpm packages
 – Install [goreleaser](https://goreleaser.com/introduction/)


### PR DESCRIPTION
Previously the line stated that the logs go in to the configuration file on the Unix system. I suspect this is unlikely and a simple copy+paste error of the configuration section above.

This change updates the README to describe the true default destination of the logs.