### PR TITLE
Simplify code according to golangci-lint warnings

### DIFF
--- a/pkg/csender/hub.go
+++ b/pkg/csender/hub.go
@@ -68,17 +68,13 @@ func (cs *Csender) GracefulSend() error {
 			if retries > retryLimit {
 				log.Errorf("csender: hub connection error, giving up")
 				return nil
-			} else {
-				log.Infof("csender: hub connection error %d/%d, retrying in %v", retries, retryLimit, retryInterval)
 			}
+			log.Infof("csender: hub connection error %d/%d, retrying in %v", retries, retryLimit, retryInterval)
 		} else {
 			return err
 		}
 
-		select {
-		case <-time.After(retryIn):
-			continue
-		}
+		time.Sleep(retryIn)
 	}
 }
 


### PR DESCRIPTION
Fixes for:
```
pkg/csender/hub.go:71:11: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
			} else {
			       ^
pkg/csender/hub.go:78:3: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
		select {
		^

```